### PR TITLE
site: dark mode

### DIFF
--- a/site/src/components/Graph.astro
+++ b/site/src/components/Graph.astro
@@ -8,7 +8,7 @@ const pos = new Map(graph.nodes.map((n) => [n.id, n]));
 ---
 <div class="graph" data-graph>
   <svg viewBox={`0 0 ${graph.w} ${graph.h}`} class="graph-svg" role="img" aria-label={`${graph.nodes.length} notes from the author's vault, linked as vir linked them`}>
-    <g class="graph-links" stroke="#141317" stroke-opacity="0.22" stroke-width="1">
+    <g class="graph-links" stroke="var(--graph-link)" stroke-opacity="0.22" stroke-width="1">
       {graph.links.map(([a, b]) => {
         const p = pos.get(a), q = pos.get(b);
         return p && q ? <line x1={p.x} y1={p.y} x2={q.x} y2={q.y} data-a={a} data-b={b} /> : null;

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -46,12 +46,12 @@ const showComposition = NUMBERS.vaultNotes !== null && NUMBERS.vaultLinks !== nu
     {proof.map((p) => <li class="px-3 first:pl-0 last:pr-0">{p}</li>)}
   </ul>
   <p class="mt-3 text-center font-mono text-[0.72rem] uppercase tracking-[0.08em] text-ink-muted">
-    <span class="text-ink/60">Works with</span>{" "}
+    <span class="text-ink-muted">Works with</span>{" "}
     {WORKS_WITH.map((w, i) => (<><span class="text-ink">{w}</span>{i < WORKS_WITH.length - 1 && <span aria-hidden="true"> · </span>}</>))}
   </p>
 
   <figure class="mt-12 md:mt-16">
-    <div class="graph-card border border-rule bg-white p-2 shadow-[0_1px_0_var(--rule),0_24px_60px_-30px_rgba(20,19,23,0.35)]">
+    <div class="graph-card border border-rule bg-card p-2 shadow-[0_1px_0_var(--rule),0_24px_60px_-30px_var(--shadow)]">
       <Graph />
       <noscript>
         <Image src={graph_png} alt={alt} widths={[640, 960, 1280]} sizes="(min-width: 1120px) 1120px, 100vw" format="webp" quality={80} loading="eager" class="h-auto w-full" />

--- a/site/src/components/Lightbox.astro
+++ b/site/src/components/Lightbox.astro
@@ -4,7 +4,7 @@ import graph from "../assets/graph.png";
 interface Props { alt: string }
 const { alt } = Astro.props;
 ---
-<dialog id="graph-lightbox" class="m-auto max-h-[92vh] max-w-[92vw] border border-rule bg-paper p-2 backdrop:bg-ink/70">
+<dialog id="graph-lightbox" class="m-auto max-h-[92vh] max-w-[92vw] border border-rule bg-paper p-2 backdrop:bg-black/70">
   <form method="dialog" class="flex justify-end">
     <button type="submit" class="font-mono text-[0.75rem] uppercase tracking-wider text-ink-muted px-2 py-1 hover:text-ink" aria-label="Close">Close ✕</button>
   </form>

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -13,6 +13,37 @@ import { GITHUB_URL, NPM_URL } from "../consts";
       <li><a class="hover:text-ink" href="#install">Install</a></li>
       <li><a class="hover:text-ink" href={GITHUB_URL}>GitHub</a></li>
       <li><a class="hover:text-ink" href={NPM_URL}>npm</a></li>
+      <li>
+        <button type="button" data-theme-toggle class="flex h-7 w-7 items-center justify-center border border-rule text-ink-muted hover:text-ink" aria-label="Toggle dark mode" title="Toggle dark mode">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+            <path class="theme-sun" d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M5.6 18.4 7 17M17 7l1.4-1.4"/><circle class="theme-sun" cx="12" cy="12" r="4"/>
+            <path class="theme-moon" d="M20 14.5A8.5 8.5 0 0 1 9.5 4a7 7 0 1 0 10.5 10.5z"/>
+          </svg>
+        </button>
+      </li>
     </ul>
   </nav>
 </header>
+
+<style is:global>
+  .theme-moon { display: none; }
+  :root[data-theme="dark"] .theme-moon { display: block; }
+  :root[data-theme="dark"] .theme-sun { display: none; }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) .theme-moon { display: block; }
+    :root:not([data-theme="light"]) .theme-sun { display: none; }
+  }
+</style>
+
+<script>
+  const btn = document.querySelector<HTMLButtonElement>("[data-theme-toggle]");
+  const root = document.documentElement;
+  const isDark = () =>
+    root.dataset.theme === "dark" ||
+    (root.dataset.theme !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+  btn?.addEventListener("click", () => {
+    const next = isDark() ? "light" : "dark";
+    root.dataset.theme = next;
+    try { localStorage.setItem("vir-theme", next); } catch {}
+  });
+</script>

--- a/site/src/components/NoteAnatomy.astro
+++ b/site/src/components/NoteAnatomy.astro
@@ -54,7 +54,7 @@ const fallback = NOTES[0];
 </section>
 
 <style is:global>
-  .note-card { border: 1px solid var(--rule); background: #fff; box-shadow: 0 1px 0 var(--rule), 0 24px 60px -30px rgba(20, 19, 23, 0.25); }
+  .note-card { border: 1px solid var(--rule); background: var(--card); box-shadow: 0 1px 0 var(--rule), 0 24px 60px -30px var(--shadow); }
   .note-bar { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 0.5rem 1rem; border-bottom: 1px solid var(--rule); padding: 0.5rem 0.75rem; }
   .note-tabs { display: flex; gap: 0.25rem; }
   .note-tab {

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -47,7 +47,14 @@ const jsonLd = {
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={og} />
-    <meta name="theme-color" content="#faf9f7" />
+    <meta name="theme-color" content="#faf9f7" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0f0f14" media="(prefers-color-scheme: dark)" />
+    <script is:inline>
+      try {
+        const t = localStorage.getItem("vir-theme");
+        if (t === "dark" || t === "light") document.documentElement.dataset.theme = t;
+      } catch {}
+    </script>
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   </head>
   <body class="bg-paper text-ink">

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -10,6 +10,43 @@
   --accent-text: #6252e0; /* 5.2:1 on paper — use for any text in accent */
   --accent-wash: color-mix(in srgb, #7c6af7 8%, transparent);
   --code-bg: #16161f;
+  --card: #ffffff;
+  --shadow: rgba(20, 19, 23, 0.35);
+  --graph-link: #141317;
+  color-scheme: light;
+}
+
+/* Dark: same accent, paper becomes near-black, ink becomes off-white.
+   Applies via system preference, or explicitly via data-theme on <html>. */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --paper: #0f0f14;
+    --paper-2: #16161d;
+    --ink: #e8e8f0;
+    --ink-muted: #9b99a8;
+    --rule: #26262f;
+    --accent-text: #a79dff; /* 7.9:1 on #0f0f14 */
+    --accent-wash: color-mix(in srgb, #7c6af7 14%, transparent);
+    --code-bg: #0a0a0f;
+    --card: #14141a;
+    --shadow: rgba(0, 0, 0, 0.6);
+    --graph-link: #e8e8f0;
+    color-scheme: dark;
+  }
+}
+:root[data-theme="dark"] {
+  --paper: #0f0f14;
+  --paper-2: #16161d;
+  --ink: #e8e8f0;
+  --ink-muted: #9b99a8;
+  --rule: #26262f;
+  --accent-text: #a79dff;
+  --accent-wash: color-mix(in srgb, #7c6af7 14%, transparent);
+  --code-bg: #0a0a0f;
+  --card: #14141a;
+  --shadow: rgba(0, 0, 0, 0.6);
+  --graph-link: #e8e8f0;
+  color-scheme: dark;
 }
 
 @theme {
@@ -22,6 +59,7 @@
   --color-accent-text: var(--accent-text);
   --color-accent-wash: var(--accent-wash);
   --color-code: var(--code-bg);
+  --color-card: var(--card);
   --font-display: "Instrument Serif", Georgia, serif;
   --font-sans: "Inter Variable", system-ui, sans-serif;
   --font-mono: "JetBrains Mono Variable", ui-monospace, monospace;


### PR DESCRIPTION
Second token set: follows prefers-color-scheme, or an explicit choice from the nav toggle (persisted in localStorage, applied before paint so there's no flash). Card, shadow, and graph-link colors tokenized; accent-text lightened to 7.9:1 on the dark paper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)