### PR TITLE
site: docs at /docs (Starlight, 12 pages)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ full-*.jpeg
 figure.jpeg
 graph-*.jpeg
 hero-logo.jpeg
+src/content/docs/docs/changelog.md
+docs-*.jpeg

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,10 +1,47 @@
 import { defineConfig } from "astro/config";
 import preact from "@astrojs/preact";
+import starlight from "@astrojs/starlight";
 import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
   site: "https://virwiki.dev",
   output: "static",
-  integrations: [preact()],
+  integrations: [
+    starlight({
+      title: "vir docs",
+      description: "An LLM Wiki for Claude Code, in your Obsidian vault.",
+      logo: { src: "./src/assets/logo.svg", alt: "vir" },
+      favicon: "/favicon.svg",
+      social: [
+        { icon: "github", label: "GitHub", href: "https://github.com/djolex999/vir" },
+        { icon: "npm", label: "npm", href: "https://www.npmjs.com/package/@djolex999/vir-cli" },
+      ],
+      customCss: [
+        "@fontsource/instrument-serif",
+        "@fontsource-variable/inter",
+        "@fontsource-variable/jetbrains-mono",
+        "./src/styles/starlight.css",
+      ],
+      editLink: { baseUrl: "https://github.com/djolex999/vir/edit/main/site/" },
+      lastUpdated: true,
+      sidebar: [
+        { label: "Getting started", slug: "docs/getting-started" },
+        { label: "How it works", slug: "docs/how-it-works" },
+        { label: "Inputs", slug: "docs/inputs" },
+        { label: "Retrieval and MCP", slug: "docs/retrieval" },
+        { label: "Keeping it current", slug: "docs/keeping-it-current" },
+        { label: "Providers and cost", slug: "docs/providers-and-cost" },
+        { label: "Configuration", slug: "docs/configuration" },
+        { label: "Commands", slug: "docs/commands" },
+        { label: "Obsidian plugin", slug: "docs/obsidian-plugin" },
+        { label: "Troubleshooting", slug: "docs/troubleshooting" },
+        { label: "Privacy", slug: "docs/privacy" },
+        { label: "Changelog", slug: "docs/changelog" },
+      ],
+      components: {},
+      disable404Route: false,
+    }),
+    preact(),
+  ],
   vite: { plugins: [tailwindcss()] },
 });

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -7,6 +7,7 @@
       "name": "vir-site",
       "dependencies": {
         "@astrojs/preact": "^6.0.5",
+        "@astrojs/starlight": "^0.42.0",
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource/instrument-serif": "^5.3.0",
@@ -297,6 +298,30 @@
         "satteri": "^0.10.3"
       }
     },
+    "node_modules/@astrojs/mdx": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-8.0.0.tgz",
+      "integrity": "sha512-4I/z+VgUO0B9I/+yhzIEpLyBYQZNJsInmrtqClP4lqX9yvUpbuV72zfRTZ8VqJLKABETUE5CYOl+23va8nqxZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.11.0",
+        "@astrojs/markdown-satteri": "0.4.0",
+        "es-module-lexer": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "@astrojs/markdown-remark": "^7.3.0",
+        "@astrojs/markdown-satteri": "^0.4.0",
+        "astro": "^7.2.6"
+      },
+      "peerDependenciesMeta": {
+        "@astrojs/markdown-remark": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@astrojs/preact": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/@astrojs/preact/-/preact-6.0.5.tgz",
@@ -327,6 +352,70 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.4.tgz",
+      "integrity": "sha512-LbKNC24bdUWcQf/pThB6qLlSqHojxGjZDURIzFocY8rlWnAn2t74nnhnK6S5x0NHriHoAduLEpVjRykmeGiVvA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/starlight": {
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.42.0.tgz",
+      "integrity": "sha512-EVsGnyGJ6rRNwGRZFYmGABo0qTQ55F7OSmfSL0VK+5lsqD+u6GWcB8tFqXETcUvP8kyn90W+QBLSL2aer9jNJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/markdown-satteri": "^0.4.0",
+        "@astrojs/mdx": "^8.0.0",
+        "@astrojs/sitemap": "^3.7.3",
+        "@pagefind/default-ui": "^1.3.0",
+        "@types/hast": "^3.0.5",
+        "@types/js-yaml": "^4.0.9",
+        "@types/mdast": "^4.0.4",
+        "astro-expressive-code": "^0.44.0",
+        "bcp-47": "^2.1.0",
+        "hast-util-format": "^1.1.0",
+        "hast-util-select": "^6.0.4",
+        "hast-util-to-html": "^9.0.5",
+        "hast-util-to-string": "^3.0.1",
+        "hastscript": "^9.0.1",
+        "i18next": "^26.0.7",
+        "js-yaml": "^4.1.1",
+        "klona": "^2.0.6",
+        "magic-string": "^1.2.3",
+        "mdast-util-directive": "^3.1.0",
+        "mdast-util-to-markdown": "^2.1.2",
+        "mdast-util-to-string": "^4.0.0",
+        "pagefind": "^1.5.2",
+        "remark-directive": "^4.0.0",
+        "satteri": "^0.10.3",
+        "ultrahtml": "^1.6.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0",
+        "vfile": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@astrojs/markdown-remark": "^7.3.0",
+        "astro": "^7.2.10"
+      },
+      "peerDependenciesMeta": {
+        "@astrojs/markdown-remark": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -842,6 +931,15 @@
         "node": ">= 20.12.0"
       }
     },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.2.0.tgz",
+      "integrity": "sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@emmetio/abbreviation": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
@@ -1328,6 +1426,51 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@expressive-code/core": {
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@expressive-code/core/-/core-0.44.2.tgz",
+      "integrity": "sha512-Yw5KonQCD1HoOO2P89y4wifqS9qrJcGVY0LkVMUsVZjhi++bhz4WwQ37inenKFNOEVo50P7cjoVsCdaVnUbq8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^4.0.4",
+        "hast-util-select": "^6.0.2",
+        "hast-util-to-html": "^9.0.1",
+        "hast-util-to-text": "^4.0.1",
+        "hastscript": "^9.0.0",
+        "postcss": "^8.4.38",
+        "postcss-nested": "^6.0.1",
+        "unist-util-visit": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.1"
+      }
+    },
+    "node_modules/@expressive-code/plugin-frames": {
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-frames/-/plugin-frames-0.44.2.tgz",
+      "integrity": "sha512-gVLm6TQMNIRWIaM7o+mCtxkGNjLZY5/2faSTLoXeo9wv/Pkj/0QAtZyXPVPrRsPARqiipATNFmfvQFLJudxPHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.44.2"
+      }
+    },
+    "node_modules/@expressive-code/plugin-shiki": {
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-shiki/-/plugin-shiki-0.44.2.tgz",
+      "integrity": "sha512-ebWIvCDzXvjyD8rH6T6DfytYJw1GoArLR4nusIAE4VxXrCQf3d+owytiv010KU/dUg+SRLZskDn0N+HaFXeuSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.44.2",
+        "shiki": "^4.0.2"
+      }
+    },
+    "node_modules/@expressive-code/plugin-text-markers": {
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.44.2.tgz",
+      "integrity": "sha512-SNI7EgUSiADqbqUzzMbj1ZeC/r2pa5eg3KyFOGAd3a7EsIA4qzjXQLp+ODWQtHVDKFCdGs4J3ovSJUqvKIK96g==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.44.2"
       }
     },
     "node_modules/@fontsource-variable/inter": {
@@ -1955,6 +2098,103 @@
       "funding": {
         "url": "https://github.com/sponsors/oxc-project"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/default-ui": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.5.2.tgz",
+      "integrity": "sha512-pm1LMnQg8N2B3n2TnjKlhaFihpz6zTiA4HiGQ6/slKO/+8K9CAU5kcjdSSPgpuk1PMuuN4hxLipUIifnrkl3Sg==",
+      "license": "MIT"
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@preact/preset-vite": {
       "version": "2.10.6",
@@ -3069,6 +3309,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3100,6 +3349,12 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -3109,6 +3364,12 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/nlcst": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
@@ -3116,6 +3377,24 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -3429,6 +3708,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3459,6 +3744,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-7.3.1.tgz",
       "integrity": "sha512-A/bJYHtc6n0UAdROY9W948fW6lX0pnUA+JWKW+IGCXRyDIGN2MsXC0OlS8onZGJjr+sv8htemwOc9W5PBRXCkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler-rs": "^0.4.0",
         "@astrojs/internal-helpers": "0.11.0",
@@ -3538,6 +3824,19 @@
         }
       }
     },
+    "node_modules/astro-expressive-code": {
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/astro-expressive-code/-/astro-expressive-code-0.44.2.tgz",
+      "integrity": "sha512-avop7nZcRwC7quvIxVguhwEZ9Tp6IoTzKUCLwP30Fb7+er+pWQgcysP01dcuzRIJo81kLGg30q/YAI2Yb1Sdzg==",
+      "license": "MIT",
+      "dependencies": {
+        "rehype-expressive-code": "^0.44.2",
+        "url-extras": "^0.1.0"
+      },
+      "peerDependencies": {
+        "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta || ^7.0.0"
+      }
+    },
     "node_modules/astro/node_modules/magic-string": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
@@ -3597,6 +3896,31 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcp-47": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.1.tgz",
+      "integrity": "sha512-KLw+H/gd2p4zly1X7Yh/qziuyae5/w/QFnvTng9eZL5fvszL7Whl3MBoWF8yxL7ksUjBfOD+OxkytiqbBpG+Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bcp-47-match": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/boolbase": {
@@ -3696,6 +4020,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
@@ -3710,6 +4044,16 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3877,6 +4221,22 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-selector-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
+      "integrity": "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -3900,6 +4260,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/csso": {
@@ -3997,6 +4369,19 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -4063,6 +4448,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/direction": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
+      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
+      "license": "MIT",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dom-serializer": {
@@ -4267,6 +4665,18 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/expressive-code": {
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/expressive-code/-/expressive-code-0.44.2.tgz",
+      "integrity": "sha512-MLNghkvhyFgVW4oCD5DxBuYnnTXIf0PygzGmfT6OZeOOYWh/D4sH1j931biElkA5RG/J9wY/iuSMGAPF5vzHOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.44.2",
+        "@expressive-code/plugin-frames": "^0.44.2",
+        "@expressive-code/plugin-shiki": "^0.44.2",
+        "@expressive-code/plugin-text-markers": "^0.44.2"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4467,6 +4877,152 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/hast-util-embedded": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
+      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-format": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-format/-/hast-util-format-1.1.0.tgz",
+      "integrity": "sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-whitespace-sensitive-tag-names": "^3.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-body-ok-link": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
+      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-minify-whitespace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
+      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-is-body-ok-link": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-select": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
+      "integrity": "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "bcp-47-match": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.0.0",
+        "direction": "^2.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "nth-check": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -4490,6 +5046,35 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -4497,6 +5082,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4528,11 +5130,49 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/html-whitespace-sensitive-tag-names": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz",
+      "integrity": "sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/i18next": {
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.4.2.tgz",
+      "integrity": "sha512-RX+R0VLg13IbvRuJSxnqykUFS9vQZTl8wYpWPCIUDWVrSGjsQywB5Y+pjzrkboxGAuYfJZVH1InFTdgBdxq6ug==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
@@ -4541,6 +5181,40 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-docker": {
@@ -4556,6 +5230,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-plain-obj": {
@@ -4652,6 +5336,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/kolorist": {
@@ -4909,6 +5602,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -4945,6 +5648,65 @@
         "source-map-js": "^1.2.1"
       }
     },
+    "node_modules/mdast-util-directive": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
@@ -4966,11 +5728,240 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
     },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
@@ -4992,6 +5983,107 @@
         "micromark-util-types": "^2.0.0"
       }
     },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
     "node_modules/micromark-util-encode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
@@ -5007,6 +6099,60 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
     },
     "node_modules/micromark-util-sanitize-uri": {
       "version": "2.0.1",
@@ -5027,6 +6173,28 @@
         "micromark-util-character": "^2.0.0",
         "micromark-util-encode": "^2.0.0",
         "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
       }
     },
     "node_modules/micromark-util-symbol": {
@@ -5299,6 +6467,49 @@
       "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
       "license": "MIT"
     },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -5366,6 +6577,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
@@ -5373,6 +6585,44 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/preact": {
@@ -5491,6 +6741,31 @@
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
+    },
+    "node_modules/rehype-expressive-code": {
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.44.2.tgz",
+      "integrity": "sha512-jvjQpsfWKBquDrEl5YQA3CJybRRIuDOYsui1BJTs5oKDUK8pPkJSSxY8FjxNlIFIdtgrTjC1zuahuY4Cc1j9SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expressive-code": "^0.44.2"
+      }
+    },
+    "node_modules/remark-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-4.0.0.tgz",
+      "integrity": "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-directive": "^3.0.0",
+        "micromark-extension-directive": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/request-light": {
       "version": "0.7.0",
@@ -5763,6 +7038,25 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
     },
     "node_modules/smol-toml": {
       "version": "1.8.0",
@@ -6053,7 +7347,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -6114,6 +7408,12 @@
         "node": ">=22.19.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -6142,6 +7442,20 @@
         "css-tree": "^3.1.0",
         "ohash": "^2.0.11",
         "undici": "^8.0.0"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/unist-util-is": {
@@ -6374,6 +7688,24 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/url-extras": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/url-extras/-/url-extras-0.1.0.tgz",
+      "integrity": "sha512-8tzwTeXFPuX/5PHuCDQE5Dd9Ts4rwoq2t9aIT+HS4iAVpmj5l4Ao7Q+BuuFjvWRqrLswBhQDk8O96ZicgCqQqw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/site/package.json
+++ b/site/package.json
@@ -6,14 +6,15 @@
     "node": ">=22.12.0"
   },
   "scripts": {
-    "dev": "astro dev",
-    "build": "astro build",
+    "dev": "node scripts/sync-changelog.mjs && astro dev",
+    "build": "node scripts/sync-changelog.mjs && astro build",
     "preview": "astro preview",
     "check": "astro check",
     "test": "vitest run"
   },
   "dependencies": {
     "@astrojs/preact": "^6.0.5",
+    "@astrojs/starlight": "^0.42.0",
     "@fontsource-variable/inter": "^5.3.0",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource/instrument-serif": "^5.3.0",

--- a/site/scripts/sync-changelog.mjs
+++ b/site/scripts/sync-changelog.mjs
@@ -1,0 +1,12 @@
+// Renders the repo CHANGELOG.md as a docs page. Runs before every build so
+// the docs never drift from the file releases are cut from.
+import { readFileSync, writeFileSync } from "node:fs";
+const src = readFileSync(new URL("../../CHANGELOG.md", import.meta.url), "utf8").replace(/^# Changelog\s*\n/, "");
+const out = `---
+title: Changelog
+description: Every vir release, newest first. Mirrors CHANGELOG.md in the repo.
+---
+
+${src}`;
+writeFileSync(new URL("../src/content/docs/docs/changelog.md", import.meta.url), out);
+console.log("changelog.md synced");

--- a/site/src/components/CreditFooter.astro
+++ b/site/src/components/CreditFooter.astro
@@ -41,6 +41,7 @@ const status = [
   <div class="container flex flex-wrap items-center justify-between gap-4 py-8 font-mono text-[0.78rem] text-ink-muted">
     <a href="#top" class="flex items-center gap-2 text-ink"><Logo size={22} /><span class="font-display text-xl leading-none">vir</span></a>
     <ul class="flex flex-wrap gap-x-5 gap-y-2">
+      <li><a class="hover:text-ink" href="/docs/getting-started/">Docs</a></li>
       <li><a class="hover:text-ink" href={GITHUB_URL}>GitHub</a></li>
       <li><a class="hover:text-ink" href={NPM_URL}>npm</a></li>
       <li><a class="hover:text-ink" href={PLUGIN_URL}>Obsidian plugin</a></li>

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -15,6 +15,7 @@ import { INSTALL_CMD } from "../consts";
     <code class="font-mono text-ink">vir run</code> does one pass over your sessions and writes notes. When you like the output,{" "}
     <code class="font-mono text-ink">vir schedule install</code> registers a daemon that keeps the vault current.
   </p>
+  <p class="prose reveal mt-4 text-[0.95rem] text-ink-muted">Full setup, configuration, and every command: <a href="/docs/getting-started/">the docs</a>.</p>
   <p class="eyebrow reveal mt-6">macOS or Linux · Node 20+ · Claude Code · Obsidian optional — the output is plain markdown either way</p>
 
   <div class="reveal mt-14 max-w-[62ch] border border-rule p-6 md:p-7">

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -10,6 +10,7 @@ import { GITHUB_URL, NPM_URL } from "../consts";
     </a>
     <ul class="flex items-center gap-5 font-mono text-[0.8rem] text-ink-muted">
       <li class="hidden sm:block"><a class="hover:text-ink" href="#how">How it works</a></li>
+      <li><a class="hover:text-ink" href="/docs/getting-started/">Docs</a></li>
       <li><a class="hover:text-ink" href="#install">Install</a></li>
       <li><a class="hover:text-ink" href={GITHUB_URL}>GitHub</a></li>
       <li><a class="hover:text-ink" href={NPM_URL}>npm</a></li>

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,0 +1,7 @@
+import { defineCollection } from "astro:content";
+import { docsLoader } from "@astrojs/starlight/loaders";
+import { docsSchema } from "@astrojs/starlight/schema";
+
+export const collections = {
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+};

--- a/site/src/content/docs/docs/changelog.md
+++ b/site/src/content/docs/docs/changelog.md
@@ -1,0 +1,247 @@
+---
+title: Changelog
+description: Every vir release, newest first. Mirrors CHANGELOG.md in the repo.
+---
+
+## 0.17.1 — 2026-09-04
+
+**Website and brand.** No CLI behavior changes.
+
+- **virwiki.dev.** Single-page site in `site/` (Astro, Preact islands, static
+  on Vercel): live graph of a real vault sample laid out at build time, the
+  note anatomy with the exact `writer.ts` frontmatter, measured numbers
+  instead of a benchmark, cost stated up front, dark mode.
+- **New mark.** The graph-spiral logo replaces the whirlpool across README,
+  the npm package asset, the site, and the Obsidian plugin (vir-obsidian
+  0.2.2 ships the matching ribbon icon).
+- README numbers re-measured: 534 tests, 396 rescued sessions, 1,386 → 410
+  transcripts-to-notes.
+
+## 0.17.0 — 2026-08-13
+
+**New distill provider: your Claude Code subscription.** `provider:
+"claude-cli"` shells out to the installed `claude` binary in print mode —
+zero per-session dollars, zero credentials. The API path (anthropic) stays
+the default for new and existing installs; this ships as an option until it
+has real mileage. Existing configs are untouched.
+
+- **`claude-cli` provider** behind the existing `callLLM` seam, alongside
+  anthropic and kie. Spawns `claude -p` with arg arrays (never a shell
+  string), prompt on stdin, JSON envelope out, per-invocation `--model`
+  pinning — hybrid routing survives. Two structural correctness
+  requirements, enforced by tests rather than convention:
+  `--no-session-persistence` always (vir never writes transcripts into
+  `~/.claude/projects` — no self-scanning, no disk bloat) and a fixed
+  neutral spawn cwd (`~/.vir`, so no project's CLAUDE.md can leak into
+  distill context). Neither has a config path that could omit it.
+- **Subscription limits are a wall, not a 429.** A detected limit
+  (`ClaudeCliLimitError`) is never retried, halts `vir run` and
+  `vir reconcile` with one message carrying the reset time, and burns no
+  per-session attempt counters — one environmental fact, not N failures
+  (the preflight-probe lesson). The detection regex is docs-sourced and
+  honestly labeled UNVERIFIED: any unrecognized error envelope is written
+  raw to daemon.log once per run as evidence, unknown errors fail safe
+  (no retry chains), the first real match stamps
+  `~/.vir/claude-cli-limit.confirmed`, and a new `vir doctor` "limit
+  detection" row reports whether the pattern has ever been confirmed.
+- **Batch cap: 25 sessions per run** on claude-cli only. Subscription quota
+  has no meter, so a big backlog is bounded per cycle (~50 CLI calls ≈ one
+  heavy interactive session); the cap is stated before the loop starts and
+  the deferred remainder is reported and picked up next run. API providers
+  are never capped.
+- **Cost honesty.** claude-cli calls land in cost.log with
+  `estimated_cost_usd: null` — cost not-applicable, never a fake $0.00
+  that would corrupt dollar aggregates. `vir cost` reports them as a
+  separate subscription-calls count, excluded from total/median/p90;
+  dry-run estimates label "subscription quota (no $)".
+- **`vir init` presents the choice honestly**, one line each: API key =
+  predictable per-session cost, no effect on Claude Code limits;
+  subscription = free and keyless, consumes your Claude Code usage limits.
+  claude-cli asks for no key. `vir doctor` authenticates it with the
+  existing claude-CLI detector plus a live ping.
+- **Re-init key survival is now enforced by schema enumeration.**
+  `buildInitConfig` had silently dropped a config key three times (bug #5,
+  the projects map, logQueries); a new test enumerates `ConfigSchema`
+  itself, so any future key must declare a survival sample and be carried
+  over — by construction, not by remembering. The test immediately caught
+  a FOURTH live drop: `embeddingProvider` (never carried since 0.15.0 — a
+  configured provider silently reset to auto-detect on re-init). Fixed.
+
+## 0.16.0 — 2026-08-13
+
+**Retrieval logging.** Every `vir query` and MCP `vir_query` retrieval now
+appends one record to a local, append-only `~/.vir/queries.jsonl` — which
+notes surfaced, at what rank and score, by which method, and how fast. The
+log is the ground truth for which notes earn their place in retrieval, and
+the baseline for future ranking work. Local-only, never transmitted; the
+synthesized answer is never recorded. Additive release: ranking, thresholds,
+and retrieval behavior are unchanged.
+
+- **Query log** (`~/.vir/queries.jsonl`, JSONL, not SQLite — the read-only
+  MCP facade must never write the DB, and file appends don't contend with
+  the daemon's SQLite lock). One record per query, written after retrieval
+  resolves and before synthesis: timestamp, source (`cli`/`mcp`), query
+  text, type filter, method (`embedding`/`tfidf`), degraded flag + reason,
+  provider provenance (name/model/dim, null on tfidf), candidate count
+  above the floor, model-mismatch exclusions, search latency, and per-hit
+  `{slug, rank, score, verified}` — `verified` per hit is how the flat
+  +0.2 `VERIFIED_BOOST` eventually gets calibrated instead of guessed.
+- **Best-effort, never silent.** A log write failure can never fail a
+  query (outer guard, unit-tested), but it emits one stderr line (stderr
+  only — MCP stdout is the JSON-RPC channel) and stamps
+  `~/.vir/queries.failed`, which the new `vir doctor` "query log" check
+  surfaces when a failure post-dates the last successful write within 7
+  days. Human table only; the 8-field `doctor --json` contract is unchanged.
+- **Rotation.** The log caps at 5 MB; at the cap it rolls to
+  `queries.jsonl.1` (one generation kept, ~10 MB bound total). Readers
+  merge both generations in order.
+- **`vir queries` (+ `--json`).** The payoff: total queries, method split,
+  degraded rate, most-surfaced notes with mean rank, and the dead-weight
+  list — notes that never surfaced in any logged query, the prune target.
+  Dead weight is suppressed (JSON: `null`, never `[]`) below 20 logged
+  queries: with a small sample "never surfaced" means unasked, not unused,
+  and the report refuses to dress noise as signal.
+- **Config: `logQueries`** (default `true`). Documented in the README:
+  logged locally, never transmitted, delete anytime, `"logQueries": false`
+  to disable.
+- `SearchOutcome` gained `candidates` and `provider` provenance fields
+  (additive, telemetry-only — never a ranking input).
+
+## 0.15.0 — 2026-07-31
+
+**Embeddings are now optional and provider-agnostic.** A new user needs only
+an API key: semantic search activates on demand, and keyword search is a
+supported floor, never an error state. Schema migration (additive), a new
+provider, and new command surface.
+
+- **Embedding model provenance.** Every embedding row stores the model and
+  dimension that produced it (`embedding_model` / `embedding_dim` on all four
+  tables; additive migration, existing rows backfill to `nomic-embed-text`/768).
+  Retrieval refuses to compare vectors from different models — cosine across
+  incompatible geometries is confident nonsense — and reports the excluded
+  count instead of silently mixing them.
+- **`EmbeddingProvider` interface** (`embedDoc`/`embedQuery`, `modelName`,
+  `dimensions`, `maxInputChars`). Ollama is now one implementation, not the
+  assumption.
+- **Local provider: `vir embed --setup`.** Installs fastembed +
+  bge-small-en-v1.5 (384d) into `~/.vir/embedder` on demand — never a package
+  dependency (the CLI tarball stays ~212 kB). States the disk cost (~233 MB +
+  ~128 MB model) and asks before touching disk or network. No node-gyp, no
+  build step, ~190 ms cold start.
+- **Provider resolution**: configured (`embeddingProvider` in config, optional)
+  > Ollama detected > local installed > none. `vir init` asks no embedding
+  question; when nothing resolves, `vir run` prints a one-line offer once per
+  run and continues on keyword search.
+- **Per-model similarity thresholds** (`RELATED_MIN_SIM`, the candidate floor)
+  moved into a per-model table. bge values calibrated against a real 389-note
+  vault by quantile-matching nomic's floors (doc-doc distributions are
+  near-identical across the two models; bge query scores run ~0.15 hotter).
+- **Honest labeling.** `via: tfidf (no provider)` is distinct from
+  `via: tfidf (embeddings failed)` — different states, different fixes.
+  `vir doctor` reports the active provider, model, dimension, alternatives
+  with their costs, and the count of notes embedded under a different model
+  (non-zero means an unfinished migration; `vir embed --force` finishes it).
+- **Model-boundary re-embeds require consent.** `vir embed --force` across a
+  model boundary states the note count and estimated time first; plain
+  `vir embed` fills same-model gaps only. The index stays queryable at every
+  point mid-migration.
+- **Context-limit fix.** Ollama serves nomic at num_ctx 2048; notes over ~8k
+  chars used to 500 and silently NULL their embedding forever. `embedText`
+  now truncates at the model limit (recorded, not silent) with reactive
+  halving, and `EmbedderError` carries a typed kind
+  (`context-limit` / `http` / `network`) so daemon.log distinguishes a
+  too-big note from a down Ollama.
+- **TF-IDF idf smoothing** (`log(1 + N/df)`): a single-note vault can now
+  find its own note (bare `log(N/df)` zeroed every term when df = N).
+  Established-vault rankings shift minimally (top-3 changes limited to
+  adjacent swaps on a 412-note corpus).
+- `OLLAMA_HOST` env var overrides the Ollama base URL (Ollama's own
+  convention).
+
+## 0.14.0 — 2026-07-31
+
+**Project-level and transcript-category distillation filtering.** Every
+filter gates at the SCAN phase — before the paid classify call — and every
+skip records a DB row with its reason; never a silent omission.
+
+- **Per-project decisions** (`projects` config map, three-state: include /
+  exclude / absent = undecided). Undecided sessions record `project-pending`
+  and wait; the daemon never prompts (macOS notification instead, behind the
+  new `notifications` flag); interactive `vir run` and `vir init` triage via
+  a multi-select showing session counts and rough costs. Multi-select
+  defaults to over-capture (undecided starts checked) — transcripts prune at
+  ~30 days, so a wrong exclude is permanent.
+- **`vir projects`**: per-project table (decision, sessions, distilled,
+  pending, excluded, est. pending cost), `include|exclude <name>`, `--json`.
+- **Project identity** decoded from transcript dir names by longest match
+  against real on-disk directories (handles dashed names, dots, deleted
+  cwds; falls back to the raw dir name, never guesses).
+- **Nested workflow/subagent transcripts** (`subagents/…`, `wf_*`) are
+  agent-internal execution, excluded by default (`workflowTranscripts`),
+  with distinct `workflow-transcript` / `sidechain-transcript` skip reasons.
+- **Top-level SDK-launched harness agents** (review/verify transcripts —
+  first user line's `entrypoint` starts with `"sdk"`) excluded by default
+  under their own `agentTranscripts` key and `agent-transcript` reason;
+  detected entrypoint persisted per session; doctor reports counts by
+  entrypoint. On the audited machine these were 67 of 97 top-level
+  transcripts.
+- **All filter skips are reversible** (flipping a decision or knob re-enters
+  the transcripts) and **forward-only** (a row holding a distilled note is
+  never overwritten — existing notes stay retrievable).
+- **One-off run scoping**: `vir run --only <p>` / `--exclude-project <p>`
+  (repeatable, never persisted).
+- **`vir doctor`**: warns on undecided projects (with oldest-transcript age
+  and the ~30-day prune deadline); informational agent-transcript line.
+- **Default provider is now anthropic + claude-sonnet-5** (Kie stays fully
+  supported; existing kie configs untouched, one-line notice on interactive
+  runs). Provider preflight probe makes an outage one clear failure instead
+  of N retry chains.
+- **`vir init` masks API-key input** and echoes only a masked confirmation.
+- New dep: `@inquirer/checkbox` (the multi-select). Additive DB migrations:
+  `skip_reason`, `entrypoint`.
+
+## 0.13.0 — 2026-07-30
+
+- **Retry bound:** 3 consecutive failed distills park a session (new
+  `sessions.attempts` column, reset on success) — `vir run` skips it even
+  under `--full`; `vir reconcile --force` is the only way back in.
+- **Process lock:** `~/.vir/vir.lock` pidfile with stale-PID reclaim
+  serializes distiller-calling commands; a second `vir run`/`vir reconcile`
+  exits immediately with the holder PID instead of double-spending.
+- **`vir schedule install` no longer starts a paid run** (`RunAtLoad` is now
+  false); new `--run-now` flag opts into an immediate first tick.
+- **`vir doctor` backup-freshness check** (renders only when
+  `~/.vir/backup.sh` exists): warns when the last successful backup is
+  older than 48h.
+
+Earlier releases (≤ 0.12.0) are documented in their annotated git tags and
+commit messages (`git log --oneline --decorate`).
+
+## 0.12.1 — 2026-07-30
+
+Bug-fix release: eight fixes, all TDD (RED → GREEN), one commit each.
+
+- `vir run --rewrite-only --dry-run` no longer rewrites the vault under the
+  dry-run banner — it reports the would-rewrite count and exits before any
+  write or index regeneration.
+- Network-level fetch failures (`TypeError` with an error `cause` — undici's
+  ECONNREFUSED/ENOTFOUND/socket-reset shape) are now retryable on the Kie
+  path; previously they burned zero retries (30 of 41 backlog rows).
+- `vir doctor`'s Ollama check performs a one-shot embedding probe instead of
+  a reachability ping; `--json`'s `ollama.model` is the probe result (null
+  when embedding fails), never an echoed constant.
+- Embedding failures during `vir query` degrade to TF-IDF *loudly*: the error
+  is surfaced, the result set is marked degraded, and the `via:` label
+  reflects what actually served the results.
+- A failed re-distill no longer records the transcript hash (hash = success
+  marker), so changed transcripts stay eligible for `vir run`; the reconcile
+  selector also claims error rows with surviving content (rescuing rows
+  already orphaned) and restores the last good note when the source
+  transcript is gone.
+- `vir doctor` distinguishes daemon "not installed" from "installed but not
+  running" — and the latter no longer reports ok.
+- The TF-IDF fallback walk skips `.rejected/` and `archived/`, so
+  human-rejected and dedupe-archived notes can never resurface via
+  `vir query` / MCP `vir_query`.
+- `docs/bug-hunt-2026-07.md` re-verified: 6 findings marked resolved with
+  source refs, 3 marked not-re-verified.

--- a/site/src/content/docs/docs/commands.md
+++ b/site/src/content/docs/docs/commands.md
@@ -1,0 +1,59 @@
+---
+title: Commands
+description: Every vir subcommand with what it costs.
+---
+
+`free` = no model call. `cheap` = classify-sized calls. `$$` = distill-sized calls per item. Every command takes `--help`.
+
+## Ingest
+
+| Command | Cost | |
+| --- | --- | --- |
+| `vir init` | free | Setup wizard: provider, models, vault, project triage |
+| `vir run` | cheap–$$ | One pass over new sessions (what the daemon runs) |
+| `vir run --dry-run` | free | Per-session estimate, exit before any call |
+| `vir run --full` | $$ | Ignore the cache, reprocess everything |
+| `vir run --rewrite-only` | free | Re-render notes from stored content, no scan, no calls |
+| `vir run --articles-only` | cheap | Only the article phase |
+| `vir run --pdfs-only` | $$ | Only the PDF phase |
+| `vir run --yes` | | Skip the >20-sessions confirmation |
+| `vir run --force-model haiku\|sonnet` | | Override the distill model this run |
+| `vir run --only <project>` / `--exclude-project <p>` | | Scope one run; records nothing |
+| `vir reconcile` | $$ | Retry sessions that failed; `--force` includes parked ones |
+| `vir calibrate <sessionId>` | $$ | Distill one session to stdout, write nothing |
+
+## Triage
+
+| Command | Cost | |
+| --- | --- | --- |
+| `vir projects` | free | Per-project decisions, counts, pending cost. `--json` |
+| `vir projects include <name>` / `exclude <name>` | free | Change one decision |
+| `vir review` | free | Approve / edit / reject new notes. `--all`, `--project`, `--limit` |
+| `vir lint` | free–cheap | Orphans and stale are free; `--contradictions` calls Haiku |
+| `vir dedupe` | cheap | Interactive duplicate detection and merge |
+
+## Retrieve
+
+| Command | Cost | |
+| --- | --- | --- |
+| `vir query "<question>"` | cheap | Search + synthesize. `--json`, `--limit` |
+| `vir queries` | free | Retrieval report: method split, dead-weight notes. `--json` |
+| `vir compose "<topic>"` | $$ | Topic page from related notes. `--dry-run`, `--limit`, `--model` |
+| `vir summarize <project>` / `--all` | cheap | Per-project synthesis |
+| `vir summarize --week [N]` / `--month [N]` | cheap | Period digest |
+| `vir embed` | free | Embed notes with the detected provider. `--force` re-embeds all |
+| `vir embed --setup` | free | Install the local embedding provider |
+| `vir mcp install` / `uninstall` / `status` | free | Register with Claude Code |
+| `vir mcp` | free | Run the MCP server over stdio |
+
+## Sync and operate
+
+| Command | Cost | |
+| --- | --- | --- |
+| `vir sync-claude [project]` | free | Diff, confirm, write between VIR markers. `--dry-run`, `--force`, `--global` |
+| `vir schedule install` / `uninstall` | free | Daemon. `--run-now` |
+| `vir status` | free | Knowledge base breakdown + daemon state |
+| `vir doctor` | cheap | 13 install/config checks. `--json` |
+| `vir cost` | free | Actual spend from cost.log. `--since`, `--top`, `--by-session` |
+
+`vir query --json` and `vir doctor --json` are stable contracts consumed by the [Obsidian plugin](/docs/obsidian-plugin/). Other `--json` outputs are for scripting and may change.

--- a/site/src/content/docs/docs/configuration.md
+++ b/site/src/content/docs/docs/configuration.md
@@ -1,0 +1,50 @@
+---
+title: Configuration
+description: Every key in ~/.vir/config.json.
+---
+
+`vir init` writes `~/.vir/config.json`. Edit it directly for anything the wizard doesn't ask about. Paths accept `~`.
+
+| Key | Default | What it does |
+| --- | --- | --- |
+| `vaultPath` | *(required)* | Absolute path to the Obsidian vault |
+| `outputDir` | `vir` | Folder inside the vault that vir owns |
+| `topicsDir` | `topics` | Subfolder for `vir compose` pages |
+| `claudeProjectsDir` | `~/.claude/projects` | Where Claude Code keeps transcripts |
+| `cadenceHours` | `3` | Daemon interval |
+| `provider` | `anthropic` | `anthropic` \| `claude-cli` \| `kie` |
+| `anthropicApiKey` | — | Required for `anthropic` |
+| `kieApiKey` | — | Required for `kie` |
+| `kieTopUpTier` | `standard` | `high` applies Kie's 10% bonus-credit discount to cost records |
+| `models.classify` | `claude-haiku-4-5-20251001` | Classify model |
+| `models.distill` | `claude-sonnet-5` | Distill model for decisions and large sessions |
+| `models.distillFast` | — | Cheaper distill model for routine sessions; set → hybrid routing on |
+| `models.distillThreshold` | `100000` | Input tokens above which `distill` is forced |
+| `filterThreshold` | `0.4` | Heuristic pre-filter floor, 0–1 |
+| `filterToolCalls` | `moderate` | Tool-output trimming before distill: `aggressive` \| `moderate` \| `off` |
+| `workflowTranscripts` | `exclude` | Workflow and sidechain transcripts: `exclude` \| `include` |
+| `agentTranscripts` | `exclude` | Headless SDK agent transcripts: `exclude` \| `include` |
+| `projects` | — | `{ "<name>": "include" \| "exclude" }`. Absent = undecided, a visible state |
+| `articlesDir` | — | Folder of clipped articles. Unset = off |
+| `distillArticles` | `true` | Gate for the article phase when `articlesDir` is set |
+| `pdfsDir` | — | Folder of PDFs. Unset = off (recommended; see Inputs) |
+| `distillPdfs` | `true` | Gate for the PDF phase when `pdfsDir` is set |
+| `embeddingProvider` | — | `ollama` \| `local` \| `none`. Unset = auto-detect |
+| `retrievalDiversity` | `0.3` | MMR diversity weight, 0–1 |
+| `logQueries` | `true` | Append retrievals to `~/.vir/queries.jsonl` |
+| `notifications` | `true` | Desktop notifications from the daemon |
+| `pricing` | built-in | Per-provider `{ "<model>": { "inputPer1M", "outputPer1M" } }` overrides |
+
+Secrets never print in full; `vir doctor` and `vir status` mask them.
+
+## Files vir keeps
+
+```
+~/.vir/config.json        configuration
+~/.vir/vir.db             SQLite: hashes, content, embeddings, skip reasons
+~/.vir/cost.log           one JSONL line per model call
+~/.vir/daemon.log         plain-text run log
+~/.vir/queries.jsonl      retrieval log, rotates at 5 MB
+~/.vir/vir.lock           run lock (pidfile)
+~/.vir/embedder/          local embedding provider, if installed
+```

--- a/site/src/content/docs/docs/getting-started.md
+++ b/site/src/content/docs/docs/getting-started.md
@@ -1,0 +1,76 @@
+---
+title: Getting started
+description: Install vir, point it at your vault, and turn months of Claude Code history into notes in one run.
+---
+
+vir reads the transcripts Claude Code already keeps on your disk and writes typed markdown notes into an Obsidian vault. This page gets you from nothing to a populated vault.
+
+## Prerequisites
+
+- macOS or Linux. Windows is not supported yet.
+- Node.js 20 or newer.
+- Claude Code, with sessions under `~/.claude/projects/`.
+- An Obsidian vault. Any folder works — the output is plain markdown — but Obsidian is where the graph and the plugin live.
+- One distill provider (you choose during `vir init`):
+  - **Anthropic API key** — predictable per-session cost, no effect on your Claude Code limits.
+  - **Your Claude Code subscription** (`claude-cli`) — free and keyless; distills consume your Claude Code usage quota.
+  - **Kie.ai API key** — a third-party proxy at roughly 28% of Anthropic list price.
+
+Semantic search is optional. Without an embedding provider vir falls back to keyword search and says so.
+
+## Install
+
+```bash
+npm install -g @djolex999/vir-cli
+vir init
+```
+
+`vir init` is an arrow-key wizard: provider, models, vault path. It also shows you every Claude Code project it found, with session counts, and asks which to include. Undecided projects stay visibly undecided — vir never silently includes or excludes.
+
+## First run
+
+Preview the cost before spending anything:
+
+```bash
+vir run --dry-run
+```
+
+This scans, filters, and prints a per-session estimate, then exits before any API call. When the number looks right:
+
+```bash
+vir run
+```
+
+vir asks for confirmation if more than 20 new sessions are queued. The first pass over a few months of history typically costs $1–$5 on the Anthropic API, or nothing on a Claude subscription.
+
+## What you'll see
+
+Open your vault. Under `<vault>/vir/` you'll find:
+
+```
+vir/
+  index.md       # catalog of every note
+  log.md         # what each run did
+  patterns/      # reusable approaches worth repeating
+  gotchas/       # bugs, footguns, edge cases
+  decisions/     # architecture decisions with rationale
+  tools/         # per-tool knowledge
+```
+
+Every note has frontmatter (`topic`, `category`, `project`, `session_id`, `date`, `confidence`), wikilinks to its project and category, and a `## Related` section linking to its nearest neighbors. Open Obsidian's graph view — the notes are already connected.
+
+## Keep it current
+
+When the output looks good, register the daemon:
+
+```bash
+vir schedule install
+```
+
+On macOS this loads a launchd agent; on Linux a systemd user timer, or a crontab entry if systemd isn't available. It runs `vir run` every 3 hours (configurable) and never prompts.
+
+## Next
+
+- [How it works](/docs/how-it-works/) — what gets filtered, what a note is made of.
+- [Retrieval and MCP](/docs/retrieval/) — ask the vault, or let Claude Code ask it mid-session.
+- [Providers and cost](/docs/providers-and-cost/) — the three providers and what they cost.

--- a/site/src/content/docs/docs/how-it-works.md
+++ b/site/src/content/docs/docs/how-it-works.md
@@ -1,0 +1,82 @@
+---
+title: How it works
+description: The pipeline from transcript to note — filtering, classification, distillation, and what a note is made of.
+---
+
+## The loop
+
+```
+Claude Code sessions → vir → Obsidian vault → CLAUDE.md → better sessions → …
+```
+
+Sessions become notes. `vir sync-claude` feeds the best notes back into your project's CLAUDE.md, with a diff and your confirmation. The next session starts knowing what the last one learned. A daemon keeps the loop turning.
+
+## The pipeline
+
+Each `vir run` does five things in order:
+
+1. **Scan.** Walk `~/.claude/projects/**/*.jsonl` and hash every file. A session is only reprocessed if its content changed, so reruns are idempotent and free.
+2. **Filter.** Drop what isn't yours before any paid call (details below).
+3. **Scrub.** Strip API keys, bearer tokens, absolute paths, and emails from what's left.
+4. **Classify.** A cheap Haiku call reads the prose of the session and returns `{category, topic, project, confidence, themes}`. Anything at or below `0.6` confidence is dropped here.
+5. **Distill.** The full transcript — tool calls included, large outputs trimmed — goes to the distill model, which writes the note body.
+
+Every step records its outcome in `~/.vir/vir.db`, so nothing is silently skipped.
+
+## What gets filtered, and why
+
+On the author's machine, 1,386 transcripts produced 410 notes. That ratio is the point: most of what Claude Code writes to disk isn't a session you drove.
+
+| Skipped as | What it is | Reversible? |
+| --- | --- | --- |
+| `workflow-transcript` | Phases of a multi-agent workflow | Yes — `workflowTranscripts: "include"` |
+| `sidechain-transcript` | Subagent runs nested under a session | Yes — same knob |
+| `agent-transcript` | Headless SDK agents (reviewers, verifiers) | Yes — `agentTranscripts: "include"` |
+| `project-excluded` | A project you excluded in `vir projects` | Yes — `vir projects include <name>` |
+| `project-pending` | A project you haven't decided on | Yes — decide |
+| *(no reason)* | Low-signal by heuristic, or classify confidence ≤ 0.6 | No |
+
+Detection is structural — directory shape and the first line's `entrypoint` field — so it costs nothing and runs before the classifier. Flipping a knob re-enters the transcripts on the next run without `--full`.
+
+## Anatomy of a note
+
+```markdown
+---
+topic: "Kie.ai returns 200 with an error body"
+aliases:
+  - "kie-ai-returns-200-with-an-error-body"
+category: gotcha
+project: "growthq"
+session_id: 4f2a9c31
+date: 2026-06-01T09:14:22.000Z
+confidence: 0.86
+themes:
+  - kie error handling
+  - retry safety
+---
+Project: [[growthq]]
+Category: [[gotcha]]
+
+The Kie.ai image endpoint answers HTTP 200 even when generation fails …
+
+## Related
+- [[retry-with-backoff-on-idempotent-writes-0c91be7a|retry-with-backoff-on-idempotent-writes]]
+```
+
+- **`topic`** is the title, chosen by the classifier after the single most durable lesson in the session — that's what makes retrieval rank a pointed note above a diary.
+- **`category`** is one of four: `pattern`, `gotcha`, `decision`, `tool`. It's also the folder the note lives in.
+- **`confidence`** is the classifier's score. The Obsidian plugin renders low-confidence notes dimmer.
+- **`session_id` + `date`** are provenance: every claim traces back to the exact session that produced it.
+- **`## Related`** is built from embedding neighbors, never from the model's guesses. On a real vault, 1 in 2,261 model-suggested links resolved; neighbor links resolve by construction.
+- **`aliases`** lets a bare `[[kebab-topic]]` reference resolve in Obsidian even though the filename carries a hash suffix.
+
+## Quality controls
+
+Auto-distilled notes can be wrong, and a wrong note that reaches CLAUDE.md makes sessions worse, not better. The controls, in the order they apply:
+
+- Transcript and project filtering before any API call.
+- The `0.6` confidence floor between classify and distill.
+- `vir review` — walk new notes, approve, edit, or reject. Verified notes rank first in retrieval; rejected ones move to `.rejected/`, recoverable.
+- `vir lint` flags orphans, stale notes, and contradictions; `vir dedupe` merges near-duplicates.
+- `vir sync-claude` never writes without showing the diff first.
+- Everything is a markdown file. Read it, edit it, delete it.

--- a/site/src/content/docs/docs/inputs.md
+++ b/site/src/content/docs/docs/inputs.md
@@ -1,0 +1,50 @@
+---
+title: Inputs
+description: Three sources feed one vault — Claude Code sessions, clipped web articles, and PDFs.
+---
+
+Each source has its own reader, its own distiller, its own SQLite table, and its own vault folder. All three embed into one vector space, so `vir query` searches across them with a `type` filter.
+
+## Claude Code sessions
+
+The original source, and the one that's retroactive: vir reads whatever is still under `~/.claude/projects/`. Claude Code prunes transcripts after roughly 30 days, so the first run recovers history that's about to disappear.
+
+Sessions run through the full [pipeline](/docs/how-it-works/) and land in `patterns/`, `gotchas/`, `decisions/`, or `tools/`.
+
+## Web articles
+
+Clip pages into a folder — Obsidian Web Clipper works well — and point `articlesDir` at it. Each clipped markdown file is classified as `concept`, `technique`, `reference`, or `opinion` and distilled into `articles/<slug>.md` with `type: article` and `source_url` in the frontmatter.
+
+Distillation is copyright-bounded: never more than 15 verbatim words from the source. The slug is keyed off the URL, so re-clipping the same page overwrites its note instead of orphaning it.
+
+```json
+{ "articlesDir": "/Users/you/Vault/clips" }
+```
+
+Run just this phase with `vir run --articles-only`. Leave `articlesDir` unset to keep the phase off.
+
+## PDFs and papers
+
+Point `pdfsDir` at a folder of PDFs. Each is classified as `paper`, `reference`, `notes`, or `other` and distilled into `pdfs/<slug>.md` with `type: pdf`, `source_path`, `source_title`, and `pages`. Same copyright bound as articles.
+
+PDFs are the expensive source — text extraction plus a full distill per file — and the daemon has no cost gate on this phase. The recommended posture is **manual only**:
+
+```bash
+# set pdfsDir in config.json, then
+vir run --pdfs-only --dry-run    # this IS the cost check — no interactive prompt
+vir run --pdfs-only
+# optionally unset pdfsDir again
+```
+
+## Where things land
+
+```
+vault/vir/
+  patterns/  gotchas/  decisions/  tools/   # sessions
+  articles/                                 # web clips
+  pdfs/                                     # papers
+  topics/                                   # vir compose syntheses
+  projects/                                 # per-project summaries
+  summaries/                                # weekly/monthly, never indexed
+  archived/                                 # dedupe losers, kept
+```

--- a/site/src/content/docs/docs/keeping-it-current.md
+++ b/site/src/content/docs/docs/keeping-it-current.md
@@ -1,0 +1,69 @@
+---
+title: Keeping it current
+description: The daemon, syncing back into CLAUDE.md, and the maintenance commands that keep a vault trustworthy.
+---
+
+## The daemon
+
+```bash
+vir schedule install            # register
+vir schedule install --run-now  # register and run once immediately
+vir schedule uninstall          # remove
+vir status                      # is it running, when did it last run
+```
+
+| Platform | Mechanism | Notifications | Status |
+| --- | --- | --- | --- |
+| macOS | launchd agent (`~/Library/LaunchAgents/com.github.djolex999.vir.plist`) | osascript | Stable |
+| Linux | systemd user timer (`~/.config/systemd/user/`) | notify-send | Experimental |
+| Linux without systemd | crontab entry | notify-send | Experimental |
+
+Cadence is `cadenceHours` in config (default 3). The daemon path never prompts: with more than 20 new sessions it proceeds; with an undecided project it notifies and skips those transcripts as `project-pending` until you decide.
+
+Distill runs are serialized by a lockfile (`~/.vir/vir.lock`), so a manual `vir run` and the daemon can't collide. A session that fails three times in a row is parked until `vir reconcile --force`.
+
+## Back into CLAUDE.md
+
+```bash
+vir sync-claude              # diff, then confirm
+vir sync-claude --dry-run    # diff only
+vir sync-claude <project>    # one project
+vir sync-claude --global     # only ~/.claude/CLAUDE.md
+```
+
+vir writes only between `<!-- VIR:START -->` and `<!-- VIR:END -->` markers. The rest of the file is preserved byte-for-byte; if there's no block yet, one is appended. Nothing is written without you seeing the diff, unless you pass `--force`.
+
+Project paths resolve flexibly: `~/projects/<slug>`, `~/projects/<slug>-*`, `~/code/<slug>`, `~/dev/<slug>`.
+
+## Review
+
+```bash
+vir review                 # walk new notes: approve / edit / reject / skip
+vir review --project <p>   # one project
+vir review --all           # include already-verified notes
+```
+
+Approve stamps `verified: true` + `reviewed_at` into the note's frontmatter. Verified notes rank first in `vir query` and MCP. Reject moves the note to `.rejected/` — recoverable, never deleted.
+
+## Lint and dedupe
+
+```bash
+vir lint                    # orphans + stale + contradictions
+vir lint --orphans          # free
+vir lint --stale            # free
+vir lint --contradictions   # a Haiku call per pair
+vir dedupe                  # interactive near-duplicate merge
+```
+
+Dedupe losers go to `archived/`. Merge winners are re-embedded so retrieval matches their new content.
+
+## Syntheses
+
+```bash
+vir compose "<topic>"          # one topic page from related notes → topics/
+vir summarize <project>        # per-project summary → projects/
+vir summarize --week [N]       # period digest → summaries/ (never indexed)
+vir summarize --month [N]
+```
+
+All take `--dry-run` (sources + cost, no call) and `--yes`.

--- a/site/src/content/docs/docs/obsidian-plugin.md
+++ b/site/src/content/docs/docs/obsidian-plugin.md
@@ -1,0 +1,27 @@
+---
+title: Obsidian plugin
+description: vir-obsidian brings the vault into Obsidian's sidebar — recent notes, related notes for what you're editing, and a daemon health dot.
+---
+
+[vir-obsidian](https://github.com/djolex999/vir-obsidian) is a separate, open-source plugin. The CLI works without it; the plugin makes the vault feel native.
+
+## What it does
+
+- **Status bar** — a health dot for the daemon: healthy, stale, down, or CLI not found. Click it to open settings.
+- **Recent tab** — every vir-distilled note in the vault, newest first, color-coded by category: patterns, gotchas, decisions, tools, articles, PDFs, topic pages.
+- **Related tab** — runs `vir query` against the note you're editing and surfaces what's relevant, so the right note finds you while you're writing.
+- **Search** — a command palette entry for `vir query` with results as clickable notes.
+- Low-confidence notes render dimmer.
+
+## Install
+
+The plugin shells out to the `vir` binary, so install the CLI first.
+
+1. Obsidian → Settings → Community plugins → Browse → search **Vir**, or install manually from the [releases page](https://github.com/djolex999/vir-obsidian/releases).
+2. Enable it. If the status dot says *CLI not found*, set the binary path in the plugin settings (`which vir` prints it).
+
+Desktop only — the plugin needs a shell, which Obsidian mobile doesn't provide.
+
+## How it talks to vir
+
+Two stable JSON contracts: `vir query --json` for results and `vir doctor --json` for health. Both are versioned with the CLI; a CLI upgrade never breaks a plugin render without a matching plugin release.

--- a/site/src/content/docs/docs/privacy.md
+++ b/site/src/content/docs/docs/privacy.md
@@ -1,0 +1,40 @@
+---
+title: Privacy
+description: What leaves your machine, what stays, and what you can turn off.
+---
+
+## What leaves
+
+**Transcript content goes to your distill provider.** Classification and distillation are model calls, so the text of a session — after scrubbing — is sent to whichever provider you configured:
+
+- `anthropic` → Anthropic's API, under your key and their data policy.
+- `claude-cli` → your own Claude Code subscription, through the `claude` binary, same as an interactive session.
+- `kie` → Kie.ai, a third-party proxy. Read their policy before choosing it.
+
+Before sending, vir strips API keys, bearer tokens, absolute filesystem paths, and email addresses. It cannot recognize every secret; if a session contains something you'd never paste into a chat, exclude that project.
+
+**Clipped articles and PDFs** likewise go to the provider when their phase runs.
+
+## What stays
+
+- The vault. Plain markdown on your disk.
+- `~/.vir/vir.db` — hashes, note content, embeddings.
+- `~/.vir/cost.log`, `daemon.log`, `queries.jsonl`.
+- Embeddings, when you use `ollama` or `local` — computed on your machine.
+
+vir has no server, no account, and no telemetry. Nothing phones home. Uninstall it and the vault is still yours.
+
+## What you control
+
+| Concern | Knob |
+| --- | --- |
+| Which projects are ever read | `vir projects exclude <name>`, or `--only` / `--exclude-project` per run |
+| Tooling transcripts (subagents, workflows, SDK agents) | Excluded by default |
+| Retrieval logging | `"logQueries": false` |
+| Desktop notifications | `"notifications": false` |
+| What reaches CLAUDE.md | Nothing without a diff and your confirmation (`vir sync-claude`) |
+| MCP exposure | Read-only server; `vir mcp uninstall` removes it |
+
+## The website
+
+virwiki.dev runs Vercel's cookie-less Web Analytics and nothing else. The graph on the landing page is a sample of the author's own vault — topic names only.

--- a/site/src/content/docs/docs/providers-and-cost.md
+++ b/site/src/content/docs/docs/providers-and-cost.md
@@ -1,0 +1,51 @@
+---
+title: Providers and cost
+description: The three distill providers, what a run costs, and every knob that controls spend.
+---
+
+vir makes two model calls per session: a cheap classify (Haiku) and a distill (the main cost). Which provider handles them is one config key.
+
+## Providers
+
+| `provider` | Auth | Cost model | Notes |
+| --- | --- | --- | --- |
+| `anthropic` (default) | `anthropicApiKey` | Per-token, Anthropic list price | Predictable; no effect on Claude Code limits |
+| `claude-cli` | none — uses the installed `claude` binary | $0; consumes your Claude Code subscription quota | Capped at 25 sessions per run; halts cleanly at a subscription limit with the reset time |
+| `kie` | `kieApiKey` | Per-token, ~28% of Anthropic | Third-party proxy; `kieTopUpTier: "high"` applies the 10% bonus-credit discount |
+
+`claude-cli` always runs with `--no-session-persistence` and a neutral working directory, so vir never writes transcripts into `~/.claude/projects` (no self-scanning) and no project's CLAUDE.md leaks into distill context. Its calls are logged with cost marked not-applicable — never a fake $0.00.
+
+## Measured cost
+
+From the author's machine, six months, Anthropic API:
+
+| | |
+| --- | --- |
+| Sessions distilled | 295 |
+| Total | $20.38 |
+| Median per session | $0.004 |
+| 90th percentile | $0.13 |
+
+Long sessions with hundreds of tool calls are the tail. vir strips large tool outputs and oversized skill loads before distilling; on one 517-tool-call session that cut input from ~217k to ~95k tokens without losing signal.
+
+## Hybrid routing
+
+Haiku captures routine and tool-heavy sessions as well as Sonnet at about a third of the cost; it only misses higher-order lessons on decision-heavy or very large sessions. When `models.distillFast` is set, each session routes after classification:
+
+- `category === "decision"` → `models.distill`
+- input tokens > `models.distillThreshold` (default 100,000) → `models.distill`
+- otherwise → `models.distillFast`
+
+`vir init` enables this by default. Existing installs are untouched on upgrade: with `distillFast` unset, `models.distill` handles everything as before.
+
+## Cost controls
+
+```bash
+vir run --dry-run              # per-session estimate, exit before any call
+vir run --force-model haiku    # override the distill model for this run
+vir cost                       # actuals from ~/.vir/cost.log: total, median, p90
+vir cost --since 30d --top 10
+vir cost --by-session
+```
+
+`vir run` asks before proceeding with more than 20 new sessions (`--yes` skips). Every recorded cost is real token usage when the provider reports it, else a chars/4 estimate, and the record says which. Pricing is provider-aware and overridable under `pricing` in config.

--- a/site/src/content/docs/docs/retrieval.md
+++ b/site/src/content/docs/docs/retrieval.md
@@ -1,0 +1,76 @@
+---
+title: Retrieval and MCP
+description: Ask the vault from the terminal, or let Claude Code consult it mid-session.
+---
+
+## `vir query`
+
+```bash
+vir query "how did we handle kie 200 errors"
+```
+
+Searches the vault, then synthesizes an answer with cited notes:
+
+```
+Kie.ai answers HTTP 200 even when generation fails; the failure only
+shows as code 422 in the body. Parse the body first, throw on
+code !== 200, and retry only on 5xx.
+
+sources
+  gotchas/kie-ai-returns-200-with-an-error-body-4f2a9c31.md
+  patterns/retry-with-backoff-on-idempotent-writes-0c91be7a.md
+```
+
+`--limit <n>` controls how many notes are retrieved (default 8). `--json` returns the machine-readable form the Obsidian plugin consumes.
+
+Verified notes (approved in `vir review`) get a flat ranking boost. Results are reranked for diversity (MMR, `retrievalDiversity`, default 0.3) so you get five different angles instead of five near-duplicates.
+
+## Search providers
+
+vir works with keyword search (TF-IDF) out of the box — no setup, ever. For semantic search, pick one embedding provider; vir auto-detects whichever is present.
+
+**Local, one command, no Ollama:**
+
+```bash
+vir embed --setup   # fastembed + bge-small-en-v1.5 into ~/.vir/embedder
+                    # ~360 MB total; states the size and asks first
+```
+
+**Or Ollama** (nomic-embed-text, 768 dimensions):
+
+```bash
+brew install ollama
+ollama pull nomic-embed-text
+ollama serve
+```
+
+Then `vir embed` once. New notes embed as they're written; a note distilled while the provider was down heals on the next run.
+
+Every stored vector records which model produced it. Vectors from different models are never compared. Switching providers means `vir embed --force`, which tells you the count and estimated time before it starts.
+
+When no provider is available, results say so: `via tfidf (no provider)`.
+
+## MCP: Claude Code asks the vault itself
+
+```bash
+vir mcp install
+```
+
+Restart Claude Code. The vault is now available mid-session through six read-only tools:
+
+| Tool | What it does |
+| --- | --- |
+| `vir_query` | Search + synthesize. `type` filter: `session` \| `article` \| `topic` \| `pdf` \| `all`. `verified_only: true` restricts to reviewed notes. |
+| `vir_status` | Note counts, categories, daemon state |
+| `vir_recent_notes` | Latest session notes |
+| `vir_recent_articles` | Latest article notes |
+| `vir_project_summary` | The cached `projects/<slug>.md`, or a pointer to `vir summarize` |
+| `vir_compose` | The cached `topics/<slug>.md`, or a pointer to `vir compose` |
+
+The server is strictly read-only: it never spends tokens and never writes files. Synthesis that costs money stays behind the CLI.
+
+`vir mcp status` checks registration; `vir mcp uninstall` removes it.
+
+## Retrieval logging
+
+Every query appends one line to `~/.vir/queries.jsonl`: the query text, which notes surfaced at what rank, the search method, and latency. Never the answer. It stays on your machine and exists so `vir queries` can report which notes earn their place and which never surface. Disable with `"logQueries": false`.

--- a/site/src/content/docs/docs/troubleshooting.md
+++ b/site/src/content/docs/docs/troubleshooting.md
@@ -1,0 +1,47 @@
+---
+title: Troubleshooting
+description: Start with vir doctor. Then the failures people actually hit.
+---
+
+## Start here
+
+```bash
+vir doctor
+```
+
+Thirteen checks: config validity, a live API-key probe, vault and output paths, session discovery, project decisions, agent-transcript detection, the SQLite schema, daemon state, backups, Ollama, the `claude` binary, MCP registration, and claude-cli limit detection. Three states each — ok, warn, fail — and a non-zero exit on any hard failure.
+
+## Common failures
+
+**`vir run` finds 0 new sessions but I have plenty.**
+Check the preflight line: `N files found · M cached · K new`. If `found` is 0, `claudeProjectsDir` is wrong. If everything is `cached`, nothing changed since the last run — that's correct. Use `vir projects` to see whether transcripts are sitting in `project-pending`.
+
+**Notes are empty or a run "succeeded" but wrote nothing.**
+A provider that answers HTTP 200 with an error in the body (Kie does this). Run `vir reconcile --dry-run` to list affected sessions, then `vir reconcile` to retry them with the cache bypassed.
+
+**The daemon isn't running.**
+`vir status` shows daemon state. On macOS, `launchctl list | grep vir`. On Linux, `systemctl --user status vir.timer`; if the user bus is unreachable (WSL, containers), vir falls back to cron — `crontab -l` shows the entry. `vir schedule uninstall && vir schedule install` re-registers.
+
+**"via tfidf (embeddings failed)" in query output.**
+Different from `(no provider)`. The provider was detected but calls failed — Ollama not serving (`ollama serve`), or the model missing (`ollama pull nomic-embed-text`). Notes that missed their embedding heal on the next run.
+
+**Query results mention excluded mismatched notes.**
+Vectors from two different embedding models exist in the vault. `vir embed --force` re-embeds everything with the current provider; it states the count first.
+
+**A session keeps failing.**
+After three consecutive failures it's parked. Fix the cause (usually the provider), then `vir reconcile --force`.
+
+**`claude-cli` runs stop early.**
+By design: 25 sessions per run, and an immediate halt at a subscription limit with the reset time. The rest are picked up on the next cycle.
+
+## Logs
+
+```
+~/.vir/daemon.log      what each run did, plain text
+~/.vir/cost.log        one line per model call
+~/.vir/queries.jsonl   one line per retrieval
+```
+
+## Getting help
+
+Issues at [github.com/djolex999/vir/issues](https://github.com/djolex999/vir/issues). Include `vir doctor --json` output, your OS and Node version, and the relevant `daemon.log` lines.

--- a/site/src/styles/starlight.css
+++ b/site/src/styles/starlight.css
@@ -1,0 +1,65 @@
+/* Map Starlight's theme onto the landing page tokens (see tokens.css). */
+:root {
+  --sl-font: "Inter Variable", system-ui, sans-serif;
+  --sl-font-mono: "JetBrains Mono Variable", ui-monospace, monospace;
+  --sl-font-system: var(--sl-font);
+  --sl-text-body: 16.5px;
+  --sl-line-height: 1.65;
+}
+:root[data-theme="light"] {
+  --sl-color-white: #141317;
+  --sl-color-gray-1: #2a2930;
+  --sl-color-gray-2: #5c5a63;
+  --sl-color-gray-3: #8a8892;
+  --sl-color-gray-4: #c9c6bf;
+  --sl-color-gray-5: #e3e0da;
+  --sl-color-gray-6: #f2f0ec;
+  --sl-color-gray-7: #f7f6f3;
+  --sl-color-black: #faf9f7;
+  --sl-color-accent-low: #ece9fe;
+  --sl-color-accent: #6252e0;
+  --sl-color-accent-high: #4a3bc7;
+  --sl-color-bg: #faf9f7;
+  --sl-color-bg-nav: rgba(250, 249, 247, 0.9);
+  --sl-color-bg-sidebar: #faf9f7;
+  --sl-color-hairline: #e3e0da;
+  --sl-color-hairline-light: #e3e0da;
+  --sl-color-hairline-shade: #e3e0da;
+  --sl-color-text: #141317;
+  --sl-color-text-accent: #6252e0;
+}
+:root[data-theme="dark"] {
+  --sl-color-white: #e8e8f0;
+  --sl-color-gray-1: #d2d1db;
+  --sl-color-gray-2: #9b99a8;
+  --sl-color-gray-3: #6b6977;
+  --sl-color-gray-4: #3a3944;
+  --sl-color-gray-5: #26262f;
+  --sl-color-gray-6: #16161d;
+  --sl-color-gray-7: #121218;
+  --sl-color-black: #0f0f14;
+  --sl-color-accent-low: #262047;
+  --sl-color-accent: #a79dff;
+  --sl-color-accent-high: #c5bdff;
+  --sl-color-bg: #0f0f14;
+  --sl-color-bg-nav: rgba(15, 15, 20, 0.9);
+  --sl-color-bg-sidebar: #0f0f14;
+  --sl-color-hairline: #26262f;
+  --sl-color-hairline-light: #26262f;
+  --sl-color-hairline-shade: #26262f;
+  --sl-color-text: #e8e8f0;
+  --sl-color-text-accent: #a79dff;
+}
+.sl-markdown-content h1, .sl-markdown-content h2, .sl-markdown-content h3, .content-panel h1, h1#_top, .site-title, .hero h1 {
+  font-family: "Instrument Serif", Georgia, serif;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+}
+.sl-markdown-content h1, .content-panel h1, h1#_top { font-size: 2.75rem; line-height: 1.05; }
+.sl-markdown-content h2 { font-size: 1.9rem; line-height: 1.15; }
+.sl-markdown-content h3 { font-size: 1.35rem; }
+.site-title { font-size: 1.4rem; }
+.sl-markdown-content code:not(pre code) { font-size: 0.86em; background: var(--sl-color-gray-6); border: 1px solid var(--sl-color-hairline); padding: 0.05em 0.35em; border-radius: 0; }
+.sl-markdown-content pre, .expressive-code .frame { border-radius: 0 !important; }
+.sl-markdown-content table { font-size: 0.92em; }
+.sidebar-content a { border-radius: 0; }


### PR DESCRIPTION
## Summary

- Starlight mounted inside the existing Astro site at `virwiki.dev/docs`, themed to the landing tokens (paper/ink/accent, Instrument Serif + Inter + JetBrains Mono), light and dark
- 12 pages written from the README and CLAUDE.md conventions, in a user register: getting started, how it works, inputs, retrieval and MCP, keeping it current, providers and cost, configuration (every key), commands (every subcommand with cost), Obsidian plugin, troubleshooting, privacy, changelog
- Changelog page is generated from the repo `CHANGELOG.md` by a prebuild script — never drifts from the file releases are cut from
- Landing nav, footer, and the install block link to the docs
- Built-in Pagefind search over the docs

Adds `@astrojs/starlight` to `site/`.

## Test plan

- [x] `npm run build` in `site/` — all 12 routes emitted
- [x] `npm test` — 14 passing
- [x] Screenshotted `/docs/how-it-works/` in light and dark
- [ ] Skim the pages on the Vercel preview for anything I got wrong about the CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)