### PR TITLE
docs: frame Kie as a testing/calibration provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ sources 4 · via embedding · searched 126
 - A distill provider — any one of:
   - Anthropic API key (predictable per-session cost, no effect on your Claude Code limits)
   - Your Claude Code subscription (`provider: "claude-cli"` — free and keyless; distills consume your Claude Code usage limits)
-  - Kie.ai API key (~72% cheaper API, third-party proxy)
+  - Kie.ai API key (~72% cheaper, third-party proxy — used for testing and calibration runs, not recommended for your real vault)
 - Optional: Ollama + `nomic-embed-text` for semantic search
 
 ## Cost

--- a/site/src/content/docs/docs/getting-started.md
+++ b/site/src/content/docs/docs/getting-started.md
@@ -14,7 +14,7 @@ vir reads the transcripts Claude Code already keeps on your disk and writes type
 - One distill provider (you choose during `vir init`):
   - **Anthropic API key** — predictable per-session cost, no effect on your Claude Code limits.
   - **Your Claude Code subscription** (`claude-cli`) — free and keyless; distills consume your Claude Code usage quota.
-  - **Kie.ai API key** — a third-party proxy at roughly 28% of Anthropic list price.
+  - **Kie.ai API key** — a third-party proxy at roughly 28% of Anthropic list price. Used for cheap testing and calibration runs; not recommended for your real vault.
 
 Semantic search is optional. Without an embedding provider vir falls back to keyword search and says so.
 

--- a/site/src/content/docs/docs/privacy.md
+++ b/site/src/content/docs/docs/privacy.md
@@ -9,7 +9,7 @@ description: What leaves your machine, what stays, and what you can turn off.
 
 - `anthropic` → Anthropic's API, under your key and their data policy.
 - `claude-cli` → your own Claude Code subscription, through the `claude` binary, same as an interactive session.
-- `kie` → Kie.ai, a third-party proxy. Read their policy before choosing it.
+- `kie` → Kie.ai, a third-party proxy. It's supported for cheap test runs; for a vault you rely on, prefer `anthropic` or `claude-cli` so transcripts go only to Anthropic.
 
 Before sending, vir strips API keys, bearer tokens, absolute filesystem paths, and email addresses. It cannot recognize every secret; if a session contains something you'd never paste into a chat, exclude that project.
 

--- a/site/src/content/docs/docs/providers-and-cost.md
+++ b/site/src/content/docs/docs/providers-and-cost.md
@@ -11,7 +11,9 @@ vir makes two model calls per session: a cheap classify (Haiku) and a distill (t
 | --- | --- | --- | --- |
 | `anthropic` (default) | `anthropicApiKey` | Per-token, Anthropic list price | Predictable; no effect on Claude Code limits |
 | `claude-cli` | none — uses the installed `claude` binary | $0; consumes your Claude Code subscription quota | Capped at 25 sessions per run; halts cleanly at a subscription limit with the reset time |
-| `kie` | `kieApiKey` | Per-token, ~28% of Anthropic | Third-party proxy; `kieTopUpTier: "high"` applies the 10% bonus-credit discount |
+| `kie` | `kieApiKey` | Per-token, ~28% of Anthropic | Third-party proxy. Kept for cheap testing and calibration runs, not recommended for your real vault; `kieTopUpTier: "high"` applies the 10% bonus-credit discount |
+
+**Which one?** `anthropic` for predictability, `claude-cli` if you already pay for Claude and don't mind distills sharing its quota. Kie exists because it's cheap enough to burn through hundreds of sessions while calibrating prompts — that's what it's used for in vir's own development. It routes your transcripts through a third party, so it isn't the right choice for the vault you actually rely on.
 
 `claude-cli` always runs with `--no-session-persistence` and a neutral working directory, so vir never writes transcripts into `~/.claude/projects` (no self-scanning) and no project's CLAUDE.md leaks into distill context. Its calls are logged with cost marked not-applicable — never a fake $0.00.
 


### PR DESCRIPTION
Providers page, getting started, privacy, and the README prerequisite now say Kie is kept for cheap test and calibration runs and is not recommended for the vault you rely on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)