### PR TITLE
site: add a /docs landing page

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -25,6 +25,7 @@ export default defineConfig({
       editLink: { baseUrl: "https://github.com/djolex999/vir/edit/main/site/" },
       lastUpdated: true,
       sidebar: [
+        { label: "Overview", slug: "docs" },
         { label: "Getting started", slug: "docs/getting-started" },
         { label: "How it works", slug: "docs/how-it-works" },
         { label: "Inputs", slug: "docs/inputs" },

--- a/site/src/components/CreditFooter.astro
+++ b/site/src/components/CreditFooter.astro
@@ -41,7 +41,7 @@ const status = [
   <div class="container flex flex-wrap items-center justify-between gap-4 py-8 font-mono text-[0.78rem] text-ink-muted">
     <a href="#top" class="flex items-center gap-2 text-ink"><Logo size={22} /><span class="font-display text-xl leading-none">vir</span></a>
     <ul class="flex flex-wrap gap-x-5 gap-y-2">
-      <li><a class="hover:text-ink" href="/docs/getting-started/">Docs</a></li>
+      <li><a class="hover:text-ink" href="/docs/">Docs</a></li>
       <li><a class="hover:text-ink" href={GITHUB_URL}>GitHub</a></li>
       <li><a class="hover:text-ink" href={NPM_URL}>npm</a></li>
       <li><a class="hover:text-ink" href={PLUGIN_URL}>Obsidian plugin</a></li>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -41,7 +41,7 @@ const showComposition = NUMBERS.vaultNotes !== null && NUMBERS.vaultLinks !== nu
     <CopyCommand command={INSTALL_CMD} class="hidden sm:inline-flex" />
     <div class="flex flex-wrap items-center justify-center gap-3">
       <a
-        href="/docs/getting-started/"
+        href="/docs/"
         class="border border-accent bg-accent px-5 py-2.5 font-mono text-[0.85rem] text-white hover:opacity-90"
         >Read the docs</a
       >

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -15,7 +15,7 @@ import { INSTALL_CMD } from "../consts";
     <code class="font-mono text-ink">vir run</code> does one pass over your sessions and writes notes. When you like the output,{" "}
     <code class="font-mono text-ink">vir schedule install</code> registers a daemon that keeps the vault current.
   </p>
-  <p class="prose reveal mt-4 text-[0.95rem] text-ink-muted">Full setup, configuration, and every command: <a href="/docs/getting-started/">the docs</a>.</p>
+  <p class="prose reveal mt-4 text-[0.95rem] text-ink-muted">Full setup, configuration, and every command: <a href="/docs/">the docs</a>.</p>
   <p class="eyebrow reveal mt-6">macOS or Linux · Node 20+ · Claude Code · Obsidian optional — the output is plain markdown either way</p>
 
   <div class="reveal mt-14 max-w-[62ch] border border-rule p-6 md:p-7">

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -10,7 +10,7 @@ import { GITHUB_URL, NPM_URL } from "../consts";
     </a>
     <ul class="flex items-center gap-5 font-mono text-[0.8rem] text-ink-muted">
       <li class="hidden sm:block"><a class="hover:text-ink" href="#how">How it works</a></li>
-      <li><a class="hover:text-ink" href="/docs/getting-started/">Docs</a></li>
+      <li><a class="hover:text-ink" href="/docs/">Docs</a></li>
       <li><a class="hover:text-ink" href="#install">Install</a></li>
       <li><a class="hover:text-ink" href={GITHUB_URL}>GitHub</a></li>
       <li><a class="hover:text-ink" href={NPM_URL}>npm</a></li>

--- a/site/src/content/docs/docs/index.md
+++ b/site/src/content/docs/docs/index.md
@@ -1,0 +1,45 @@
+---
+title: vir documentation
+description: Everything about vir — installing it, what it writes, how retrieval works, what it costs, and every command.
+tableOfContents: false
+---
+
+vir reads the Claude Code transcripts already on your disk, filters out what isn't yours, and writes typed markdown notes into an Obsidian vault. It's a CLI, an MCP server, and an Obsidian plugin. Nothing is hosted.
+
+New here? **[Getting started](/docs/getting-started/)** takes about five minutes.
+
+## Start
+
+| | |
+| --- | --- |
+| **[Getting started](/docs/getting-started/)** | Prerequisites, install, your first run, and what appears in the vault |
+| **[How it works](/docs/how-it-works/)** | The pipeline, what gets filtered and why, the anatomy of a note, and the quality controls |
+| **[Inputs](/docs/inputs/)** | The three sources: Claude Code sessions, clipped web articles, PDFs |
+
+## Use it
+
+| | |
+| --- | --- |
+| **[Retrieval and MCP](/docs/retrieval/)** | `vir query`, embedding providers, and letting Claude Code consult the vault mid-session |
+| **[Keeping it current](/docs/keeping-it-current/)** | The daemon, `sync-claude`, review, lint, dedupe, and syntheses |
+| **[Commands](/docs/commands/)** | Every subcommand, with what it costs |
+
+## Configure it
+
+| | |
+| --- | --- |
+| **[Providers and cost](/docs/providers-and-cost/)** | The three distill providers, measured spend, hybrid routing, and every cost control |
+| **[Configuration](/docs/configuration/)** | Every key in `~/.vir/config.json`, with defaults |
+| **[Obsidian plugin](/docs/obsidian-plugin/)** | The sidebar: recent notes, related notes, daemon health |
+
+## When something's off
+
+| | |
+| --- | --- |
+| **[Troubleshooting](/docs/troubleshooting/)** | Start with `vir doctor`, then the failures people actually hit |
+| **[Privacy](/docs/privacy/)** | What leaves your machine, what stays, and what you can turn off |
+| **[Changelog](/docs/changelog/)** | Every release, newest first |
+
+## Elsewhere
+
+[GitHub](https://github.com/djolex999/vir) · [npm](https://www.npmjs.com/package/@djolex999/vir-cli) · [Obsidian plugin](https://github.com/djolex999/vir-obsidian) · [Report an issue](https://github.com/djolex999/vir/issues)


### PR DESCRIPTION
`/docs` had no index, so only the deep links resolved — and `/docs` is the URL people type and paste. Adds an overview grouping the twelve pages by intent (start / use it / configure it / when something's off), puts it first in the sidebar, and retargets the landing page's four Docs links from `/docs/getting-started/` to `/docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)