### PR TITLE
site: RSS feed for releases, follow block, restored site README

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,59 @@
+# vir marketing site
+
+virwiki.dev — the landing page plus `/docs`. Spec: `../docs/superpowers/specs/2026-09-02-website-design.md`.
+Conventions that matter live in `../CLAUDE.md` under **Website (`site/`)**.
+
+## Run
+
+Astro 7 needs Node ≥ 22.12 — nvm's default here is 20, so either `nvm use 22` or
+prefix with Homebrew's node:
+
+```bash
+PATH=/opt/homebrew/bin:$PATH npm run dev
+```
+
+`npm run build` · `npm run preview` · `npm test` · `npm run check`
+
+## Where things live
+
+- `src/consts.ts` — every URL and number on the site, each with its derivation in a
+  comment. `SITE_URL` is the only place the domain is set. A `null` in `NUMBERS`
+  means unmeasured: the block that needs it is omitted and the build prints the key.
+- `src/data/notes.ts` — the four sample notes in the Anatomy block, in the exact
+  shape `../src/pipeline/writer.ts` emits. **Change both together.**
+- `src/lib/stats.ts` — build-time npm downloads and GitHub stars. Any failure omits
+  the figure; it never fails the build.
+- `src/islands/` — the two hydrated components (`Loop`, `NoteTabs`). Preact, not
+  React. Everything else is static HTML.
+- `src/content/docs/docs/` — the Starlight pages. `changelog.md` is **generated** by
+  `scripts/sync-changelog.mjs` on every build; edit `../CHANGELOG.md` instead.
+- `src/pages/changelog.xml.ts` — the release RSS feed, parsed from the same file.
+
+## Regenerating artifacts
+
+**The hero graph** is laid out at build time and committed, because Vercel has no
+vault:
+
+```bash
+node scripts/build-graph.mjs          # reads the vault from ~/.vir/config.json
+```
+
+Topics matching `leak|bypass|attack|inject|exploit|vuln|self-grant|secur` are
+excluded from the public sample.
+
+**The OG card** is `scripts/og.html`, screenshotted at 1200×630:
+
+```bash
+npm i -D playwright && npx playwright install chromium
+node scripts/build-og.mjs
+npm un playwright
+```
+
+Playwright is deliberately not a dependency — it downloads a browser on postinstall
+and Vercel installs devDependencies on every build.
+
+## Deploy
+
+Vercel project, root directory `site/`, framework preset Astro, static output. No
+adapter. Analytics is Vercel Web Analytics via the inline script in `Base.astro`
+(404s locally — that's expected).

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -22,6 +22,17 @@ export default defineConfig({
         "@fontsource-variable/jetbrains-mono",
         "./src/styles/starlight.css",
       ],
+      head: [
+        {
+          tag: "link",
+          attrs: {
+            rel: "alternate",
+            type: "application/rss+xml",
+            title: "vir releases",
+            href: "/changelog.xml",
+          },
+        },
+      ],
       editLink: { baseUrl: "https://github.com/djolex999/vir/edit/main/site/" },
       lastUpdated: true,
       sidebar: [

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -7,6 +7,7 @@
       "name": "vir-site",
       "dependencies": {
         "@astrojs/preact": "^6.0.5",
+        "@astrojs/rss": "^4.0.19",
         "@astrojs/starlight": "^0.42.0",
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
@@ -352,6 +353,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.19.tgz",
+      "integrity": "sha512-e+z5wYeYtffQdHQO8c2tkSd2JEBdAuRXJV4ZEU5IxkYeE6e39woDd7nw1PH1Kk2tEYNCYuKdylnnbhGmt61awA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -2084,6 +2096,18 @@
         "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
@@ -3708,6 +3732,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -4731,6 +4767,45 @@
         "fast-string-width": "^3.0.2"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
+      "integrity": "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.11.1.tgz",
+      "integrity": "sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.2",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5253,6 +5328,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.2.tgz",
+      "integrity": "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/jiti": {
       "version": "2.7.0",
@@ -6517,6 +6604,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -7187,6 +7289,21 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.2.tgz",
+      "integrity": "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
     },
     "node_modules/svgo": {
       "version": "4.1.0",
@@ -8733,6 +8850,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/site/package.json
+++ b/site/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@astrojs/preact": "^6.0.5",
+    "@astrojs/rss": "^4.0.19",
     "@astrojs/starlight": "^0.42.0",
     "@fontsource-variable/inter": "^5.3.0",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",

--- a/site/src/components/CreditFooter.astro
+++ b/site/src/components/CreditFooter.astro
@@ -44,6 +44,7 @@ const status = [
       <li><a class="hover:text-ink" href="/docs/">Docs</a></li>
       <li><a class="hover:text-ink" href={GITHUB_URL}>GitHub</a></li>
       <li><a class="hover:text-ink" href={NPM_URL}>npm</a></li>
+      <li><a class="hover:text-ink" href="/changelog.xml">RSS</a></li>
       <li><a class="hover:text-ink" href={PLUGIN_URL}>Obsidian plugin</a></li>
       <li><a class="hover:text-ink" href={`${GITHUB_URL}/blob/main/LICENSE`}>MIT license</a></li>
       <li>GrowthQ Lab DOO</li>

--- a/site/src/components/Follow.astro
+++ b/site/src/components/Follow.astro
@@ -1,0 +1,41 @@
+---
+import { GITHUB_URL, NPM_URL } from "../consts";
+import { formatCount, type Stats } from "../lib/stats";
+
+interface Props { stats: Stats }
+const { stats } = Astro.props;
+---
+<section class="bg-paper-2">
+  <div class="section container">
+    <p class="eyebrow reveal">Follow along</p>
+    <h2 class="reveal mt-3 font-display text-4xl leading-tight md:text-5xl">Solo project, shipping in public.</h2>
+    <p class="prose reveal mt-5 text-ink-muted">
+      No mailing list, no account. Three ways to see what changes, all of them ones you already use.
+    </p>
+    <ul class="reveal mt-10 grid gap-px border border-rule bg-rule md:grid-cols-3">
+      <li class="bg-paper-2 p-6 md:p-7">
+        <a class="font-display text-[1.45rem] leading-tight text-ink underline decoration-rule underline-offset-4 hover:decoration-accent" href={GITHUB_URL}>Star on GitHub</a>
+        <p class="mt-3 text-[0.95rem] text-ink-muted">
+          {stats.stars === null
+            ? "Where the code, the issues, and the roadmap live."
+            : `${formatCount(stats.stars)} so far. Where the code, the issues, and the roadmap live.`}
+        </p>
+      </li>
+      <li class="bg-paper-2 p-6 md:p-7">
+        <a class="font-display text-[1.45rem] leading-tight text-ink underline decoration-rule underline-offset-4 hover:decoration-accent" href={`${GITHUB_URL}/releases`}>Watch releases</a>
+        <p class="mt-3 text-[0.95rem] text-ink-muted">
+          GitHub → Watch → Custom → Releases. One notification per version, nothing else.
+        </p>
+      </li>
+      <li class="bg-paper-2 p-6 md:p-7">
+        <a class="font-display text-[1.45rem] leading-tight text-ink underline decoration-rule underline-offset-4 hover:decoration-accent" href="/changelog.xml">Subscribe by RSS</a>
+        <p class="mt-3 text-[0.95rem] text-ink-muted">
+          <code class="font-mono text-ink">virwiki.dev/changelog.xml</code> — every release note, in your reader.
+        </p>
+      </li>
+    </ul>
+    <p class="prose reveal mt-6 text-[0.95rem] text-ink-muted">
+      Also on <a href={NPM_URL}>npm</a>, and the full history is on the <a href="/docs/changelog/">changelog</a>.
+    </p>
+  </div>
+</section>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -36,6 +36,7 @@ const jsonLd = {
     <meta name="description" content={description} />
     <link rel="canonical" href={canonical} />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="alternate" type="application/rss+xml" title="vir releases" href="/changelog.xml" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />

--- a/site/src/lib/changelog.test.ts
+++ b/site/src/lib/changelog.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { parseReleases } from "../pages/changelog.xml";
+
+const SAMPLE = `# Changelog
+
+## 0.17.1 — 2026-09-04
+
+Website and brand. No CLI changes.
+
+- One thing
+- Another
+
+## 0.17.0 — 2026-08-13
+
+Subscription provider.
+
+- Detail
+`;
+
+describe("parseReleases", () => {
+  it("finds every release, newest first, in file order", () => {
+    const r = parseReleases(SAMPLE);
+    expect(r.map((x) => x.version)).toEqual(["0.17.1", "0.17.0"]);
+  });
+  it("parses the date as UTC midday so timezones can't shift the day", () => {
+    expect(parseReleases(SAMPLE)[0]!.date.toISOString()).toBe("2026-09-04T12:00:00.000Z");
+  });
+  it("stops a release body at the next heading", () => {
+    const [first] = parseReleases(SAMPLE);
+    expect(first!.body).toContain("- Another");
+    expect(first!.body).not.toContain("Subscription provider");
+  });
+  it("returns nothing when there are no release headings", () => {
+    expect(parseReleases("# Changelog\n\nnothing here\n")).toEqual([]);
+  });
+});

--- a/site/src/pages/changelog.xml.ts
+++ b/site/src/pages/changelog.xml.ts
@@ -1,0 +1,53 @@
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { SITE_URL } from "../consts";
+
+interface Release {
+  version: string;
+  date: Date;
+  body: string;
+}
+
+// One feed item per release, parsed from the repo CHANGELOG.md — the same
+// file `scripts/sync-changelog.mjs` renders as the docs page, so the feed can
+// never disagree with the site.
+export function parseReleases(md: string): Release[] {
+  const out: Release[] = [];
+  const heading = /^## (\d+\.\d+\.\d+)\s+[—-]\s+(\d{4}-\d{2}-\d{2})\s*$/gm;
+  const marks: { version: string; date: string; start: number; end: number }[] = [];
+  for (const m of md.matchAll(heading)) {
+    const at = m.index ?? 0;
+    const prev = marks[marks.length - 1];
+    if (prev) prev.end = at;
+    marks.push({ version: m[1]!, date: m[2]!, start: at + m[0].length, end: md.length });
+  }
+  for (const k of marks) {
+    out.push({
+      version: k.version,
+      date: new Date(`${k.date}T12:00:00Z`),
+      body: md.slice(k.start, k.end).trim(),
+    });
+  }
+  return out;
+}
+
+export async function GET(context: APIContext) {
+  // cwd is site/ during `astro build`; import.meta.url is unreliable once bundled.
+  const md = readFileSync(resolve(process.cwd(), "..", "CHANGELOG.md"), "utf8");
+  const releases = parseReleases(md).slice(0, 30);
+  return rss({
+    title: "vir releases",
+    description: "Release notes for vir, an LLM Wiki for Claude Code in your Obsidian vault.",
+    site: context.site ?? SITE_URL,
+    items: releases.map((r) => ({
+      title: `vir ${r.version}`,
+      pubDate: r.date,
+      link: `${SITE_URL}/docs/changelog/`,
+      description: r.body.split("\n\n")[0]?.replace(/\n/g, " ").slice(0, 400) ?? "",
+      content: r.body,
+    })),
+    customData: "<language>en</language>",
+  });
+}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -11,6 +11,7 @@ import QueryAndMcp from "../components/QueryAndMcp.astro";
 import NoBenchmark from "../components/NoBenchmark.astro";
 import Cost from "../components/Cost.astro";
 import Install from "../components/Install.astro";
+import Follow from "../components/Follow.astro";
 import CreditFooter from "../components/CreditFooter.astro";
 import { fetchStats } from "../lib/stats";
 import { MEASURE } from "../consts";
@@ -37,6 +38,7 @@ if (MEASURE.length > 0) {
     <NoBenchmark />
     <Cost />
     <Install />
+    <Follow stats={stats} />
   </main>
   <CreditFooter />
 </Base>


### PR DESCRIPTION
**Follow.** The changelog was readable but not subscribable and the star count was hidden. Adds:

- `/changelog.xml` — one item per release, parsed from `CHANGELOG.md` (the same file the docs page renders, so the two can't disagree). 4 unit tests on the parser.
- `<link rel="alternate">` discovery on the landing layout and every Starlight page.
- A **Follow along** block: star on GitHub with the live count, watch releases, subscribe by RSS. No mailing list, no account.
- RSS in the footer links.

**Also:** `site/README.md` was lost in the rebase during the domain PR. Restored and expanded with the graph and OG regeneration procedures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)