### PR TITLE
fix: deterministic related-link tests, guarded test count

### DIFF
--- a/site/scripts/refresh.mjs
+++ b/site/scripts/refresh.mjs
@@ -30,11 +30,15 @@ for (const p of q("select path from sessions where skipped=0 and note_paths!='[]
   }
 }
 
-// The CLI targets Node 20; the site needs 22+ for Astro 7. Running the CLI
-// suite under the site's newer runtime reports 38 failures that don't exist
-// on 20, so the count is stamped with the version that produced it.
+// The CLI targets Node 20 and pins a native better-sqlite3 build to it; the
+// site needs Node 22+ for Astro 7. Running the CLI suite under the site's
+// runtime fails every DB test with a NODE_MODULE_VERSION mismatch, which is
+// an environment fault, not a result. Refuse to report a number rather than
+// print a wrong one.
 const nodeMajor = Number(process.versions.node.split(".")[0]);
-console.log(`→ counting CLI tests (node ${process.versions.node})`);
+const canCountTests = nodeMajor === 20;
+if (canCountTests) console.log(`→ counting CLI tests (node ${process.versions.node})`);
+else console.log(`→ skipping CLI tests — node ${nodeMajor}, the CLI needs node 20`);
 // vitest prints its summary on stderr, and on a failure the line reads
 // "Tests  1 failed | 533 passed (534)" — matching only /(\d+) passed/ would
 // silently report a green count for a red suite, which is exactly the kind of
@@ -49,7 +53,7 @@ const readTests = (text) => {
 };
 let tests = null;
 let testsFailed = 0;
-try {
+if (canCountTests) try {
   const r = readTests(execFileSync("npm", ["test", "--silent"], { cwd: repo, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }));
   tests = r.passed;
   testsFailed = r.failed;
@@ -67,7 +71,7 @@ const rows = [
   ["transcriptsSeen", seen],
   ["transcriptsNoise", noise],
   ["transcriptsNotes", withNote],
-  ["tests", tests],
+  ...(canCountTests ? [["tests", tests]] : []),
 ];
 
 console.log("\nsrc/consts.ts — NUMBERS\n");
@@ -81,9 +85,9 @@ for (const [k, v] of rows) {
     `  ${k.padEnd(20)}${String(Number.isNaN(was) ? "—" : was).padStart(9)}${String(v ?? "—").padStart(13)}${same ? "" : "   ← update"}`,
   );
 }
-if (nodeMajor > 20) {
+if (!canCountTests) {
   console.log(
-    `\n  ⚠ counted under node ${nodeMajor}; the CLI targets node 20 and reports a\n    different number there. Re-run the CLI suite on 20 before trusting this.`,
+    `\n  ⚠ tests not counted: node ${nodeMajor} can't load this better-sqlite3 build.\n    Run \`nvm use 20 && npm test\` at the repo root and read the number there.`,
   );
 }
 if (testsFailed > 0) {

--- a/src/lint/linter.test.ts
+++ b/src/lint/linter.test.ts
@@ -1,27 +1,39 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Config } from "../config.js";
 import type { DistilledNote, ParsedSession } from "../pipeline/types.js";
 
-vi.mock("../search/embedder.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../search/embedder.js")>();
-  return {
-    ...actual,
-    isOllamaAvailableCached: vi.fn(async () => true),
-    embeddingForNote: vi.fn(async (text: string) => {
-      // Both notes are retry-themed → near-identical vectors → neighbors.
-      if (text.includes("Retry Backoff Strategy")) return [1, 0.1];
-      if (text.includes("Kie Timeout Handling")) return [1, 0.2];
-      return [0, 1];
-    }),
-  };
-});
-
 import { VaultWriter } from "../pipeline/writer.js";
+import type { EmbeddingProvider } from "../search/provider.js";
 import { StateDb } from "../state/db.js";
 import { orphanCheck } from "./linter.js";
+
+// Related links come from embedding neighbors, so these tests need a provider.
+// Injected rather than resolved: auto-detection made the result depend on
+// whether Ollama happened to be running on the machine, and the previous
+// vi.mock targeted embedder.js functions the writer stopped calling in 0.15.0
+// — so the suite passed only because a live Ollama made the real path work.
+const stubProvider: EmbeddingProvider = {
+  name: "ollama",
+  modelName: "nomic-embed-text",
+  dimensions: 2,
+  maxInputChars: 8192,
+  available: async () => true,
+  // Both notes are retry-themed → near-identical vectors → neighbors.
+  embedDoc: async (text: string) => ({
+    embedding: text.includes("Retry Backoff Strategy")
+      ? [1, 0.1]
+      : text.includes("Kie Timeout Handling")
+        ? [1, 0.2]
+        : [0, 1],
+    sentChars: text.length,
+    truncated: false,
+  }),
+  embedQuery: async () => [1, 0.15],
+  provenance: () => ({ model: "nomic-embed-text", dim: 2 }),
+};
 
 function makeCfg(vaultPath: string): Config {
   return {
@@ -90,7 +102,7 @@ describe("orphanCheck wikilink resolution", () => {
   it("resolves a writer-emitted related-link to the existing target note", async () => {
     const cfg = makeCfg(vault);
     const db = new StateDb(join(vault, "vir.db"));
-    const writer = new VaultWriter(cfg, db);
+    const writer = new VaultWriter(cfg, db, stubProvider);
 
     db.record({
       path: "/x/aaaa1111.jsonl", hash: "h1", skipped: false,

--- a/src/pipeline/writer.ts
+++ b/src/pipeline/writer.ts
@@ -58,10 +58,19 @@ export class VaultWriter {
   // spot; the self-heal sweep back-fills them next run.
   embedSkipped = 0;
 
-  constructor(cfg: Config, db: StateDb | null = null) {
+  // Tests only. Related links come from embedding neighbors (0.12.0), so a
+  // writer with no provider emits none — which made the link tests assert
+  // whatever happened to be installed on the machine rather than the contract.
+  // Production callers pass nothing and keep resolveEmbeddingProvider.
+  constructor(
+    cfg: Config,
+    db: StateDb | null = null,
+    providerOverride?: EmbeddingProvider,
+  ) {
     this.root = join(cfg.vaultPath, cfg.outputDir);
     this.db = db;
     this.embeddingChoice = cfg.embeddingProvider;
+    if (providerOverride) this.providerPromise = Promise.resolve(providerOverride);
     this.topicsDir = cfg.topicsDir ?? TOPICS_SUBDIR;
     for (const sub of [
       ...Object.values(CATEGORY_DIR),


### PR DESCRIPTION
Two things, one root cause each.

**The suite was green by luck.** `src/lint/linter.test.ts` mocked `isOllamaAvailableCached` and `embeddingForNote` from `search/embedder.js` — functions the writer stopped calling in the 0.15.0 provider refactor. The mock became inert, the writer resolved a *real* provider instead, and the test passed because Ollama happened to be running on this machine. It went red the day it wasn't, and would have failed on any other machine or in CI.

`VaultWriter` now takes an optional `EmbeddingProvider` as a third constructor arg — a test-only seam, matching the `fetchImpl` seam in `callKie`. The test injects a stub with fixed vectors and asserts the linking contract instead of the environment. 534/534 green on Node 20.

**38 "failures" on Node 23 were one environment fault.** `better-sqlite3` is a native build for Node 20 (`NODE_MODULE_VERSION 115`); Node 22+, which `site/` needs for Astro 7, wants 131. Every DB test dies at `new Database()` and the rest cascade from an undefined `db` in `afterEach`. `npm run refresh` now refuses to report a test count from the wrong runtime rather than printing a wrong one.

Both conventions are documented in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)