### PR TITLE
docs: correct the doctor check count, flag the pending-projects deadline

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ with your distro, init system, and Node version.
 | `vir embed --setup`         | free  | Install the local embedding provider (no Ollama needed) |
 | `vir schedule install`      | free  | Register the background daemon            |
 | `vir status`                | free  | Knowledge base breakdown + daemon status  |
-| `vir doctor`                | cheap | 13 install/config checks                  |
+| `vir doctor`                | cheap | 15 install/config checks                  |
 | `vir reconcile`             | $$    | Retry sessions that failed, cache-bypassed |
 | `vir mcp install`           | free  | Register the MCP server with Claude Code  |
 

--- a/site/src/content/docs/docs/commands.md
+++ b/site/src/content/docs/docs/commands.md
@@ -53,7 +53,7 @@ description: Every vir subcommand with what it costs.
 | `vir sync-claude [project]` | free | Diff, confirm, write between VIR markers. `--dry-run`, `--force`, `--global` |
 | `vir schedule install` / `uninstall` | free | Daemon. `--run-now` |
 | `vir status` | free | Knowledge base breakdown + daemon state |
-| `vir doctor` | cheap | 13 install/config checks. `--json` |
+| `vir doctor` | cheap | 15 install/config checks. `--json` |
 | `vir cost` | free | Actual spend from cost.log. `--since`, `--top`, `--by-session` |
 
 `vir query --json` and `vir doctor --json` are stable contracts consumed by the [Obsidian plugin](/docs/obsidian-plugin/). Other `--json` outputs are for scripting and may change.

--- a/site/src/content/docs/docs/obsidian-plugin.md
+++ b/site/src/content/docs/docs/obsidian-plugin.md
@@ -17,7 +17,7 @@ description: vir-obsidian brings the vault into Obsidian's sidebar — recent no
 
 The plugin shells out to the `vir` binary, so install the CLI first.
 
-1. Obsidian → Settings → Community plugins → Browse → search **Vir**, or install manually from the [releases page](https://github.com/djolex999/vir-obsidian/releases).
+1. Obsidian → Settings → Community plugins → Browse → search **Vir** (plugin id `vir`). Or install manually from the [releases page](https://github.com/djolex999/vir-obsidian/releases).
 2. Enable it. If the status dot says *CLI not found*, set the binary path in the plugin settings (`which vir` prints it).
 
 Desktop only — the plugin needs a shell, which Obsidian mobile doesn't provide.

--- a/site/src/content/docs/docs/troubleshooting.md
+++ b/site/src/content/docs/docs/troubleshooting.md
@@ -9,7 +9,9 @@ description: Start with vir doctor. Then the failures people actually hit.
 vir doctor
 ```
 
-Thirteen checks: config validity, a live API-key probe, vault and output paths, session discovery, project decisions, agent-transcript detection, the SQLite schema, daemon state, backups, Ollama, the `claude` binary, MCP registration, and claude-cli limit detection. Three states each — ok, warn, fail — and a non-zero exit on any hard failure.
+Fifteen checks: config validity, a live API-key probe, vault path, output directory, session discovery, project decisions, agent-transcript detection, the SQLite database, daemon state, backups, the query log, Ollama, the embedding provider, the `claude` binary, and MCP registration. Three states each — ok, warn, fail — and a non-zero exit on any hard failure.
+
+One of them is time-sensitive and easy to miss: **project decisions**. Transcripts from a project you haven't included or excluded sit as `project-pending` and are never distilled — and Claude Code prunes them at around 30 days. Doctor tells you the age of the oldest one, because past that point the decision is moot.
 
 ## Common failures
 


### PR DESCRIPTION
Ran the commands instead of trusting the README.

`vir doctor` runs **15** checks, not 13 — the README, `CLAUDE.md` and the docs all carried a number frozen at 0.14.0. Corrected in the commands table, the README, and Troubleshooting, which now lists the actual checks.

Troubleshooting also gains a note on **project decisions**, which is the one time-sensitive check: pending transcripts are never distilled and Claude Code prunes them at ~30 days, so an undecided project quietly becomes a permanent loss. Doctor reports the oldest one's age; on this machine it's 33 days, which is already past.

Plugin page: verified `vir` is in `community-plugins.json`, so the Community-plugins instruction is accurate. Added the plugin id and demoted the manual path to a fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)