### PR TITLE
fix: a rejected note no longer comes back on re-distill

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ developer-tools, mcp, local-first, cross-platform, llm-wiki
   <a href="https://www.npmjs.com/package/@djolex999/vir-cli"><img src="https://img.shields.io/npm/v/@djolex999/vir-cli?color=7c6af7&label=npm" alt="npm version"></a>
   <a href="https://www.npmjs.com/package/@djolex999/vir-cli"><img src="https://img.shields.io/npm/dw/@djolex999/vir-cli?color=4fd1a0" alt="npm downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22d3ee" alt="license"></a>
-  <a href="#project-status"><img src="https://img.shields.io/badge/tests-534%20passing-22c55e" alt="tests"></a>
+  <a href="#project-status"><img src="https://img.shields.io/badge/tests-535%20passing-22c55e" alt="tests"></a>
   <a href="#project-status"><img src="https://img.shields.io/badge/platforms-macOS%20%7C%20Linux-lightgrey" alt="platforms"></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-server-c084fc" alt="mcp"></a>
   <a href="#"><img src="https://img.shields.io/badge/local--first-yes-f59e0b" alt="local-first"></a>
@@ -505,7 +505,7 @@ improvements. Delete it any time; disable it with `"logQueries": false` in
 |                |                                           |
 | -------------- | ----------------------------------------- |
 | Version        | 0.17.1                                    |
-| Tests          | 534 passing                               |
+| Tests          | 535 passing                               |
 | Platforms      | macOS (launchd), Linux (systemd/cron)     |
 | Node           | 20+                                       |
 | First-run cost | $1 to $5 (Kie.ai optional, ~72% cheaper)  |

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -23,14 +23,14 @@ export const INSTALL_CMD = `npm install -g ${NPM_PKG}`;
 //   transcriptsSeen  — rows in the sessions table
 //   transcriptsNoise — skip_reason in (workflow-transcript, agent-transcript, sidechain-transcript)
 //   transcriptsNotes — skipped=0 and note_paths != '[]'
-//   tests            — `npm test` at the repo root (534 CLI; the site's 18 are separate)
+//   tests            — `npm test` at the repo root (535 CLI; the site's 18 are separate)
 //   cost*            — `vir cost --since 180d`
 export const NUMBERS = {
   sessionsRescued: 396,
   transcriptsSeen: 1429,
   transcriptsNoise: 601,
   transcriptsNotes: 411,
-  tests: 534 as number | null,
+  tests: 535 as number | null,
   costWindow: "six months",
   costSessions: 296,
   costTotal: "$22.23" as string | null,

--- a/src/cli/review.ts
+++ b/src/cli/review.ts
@@ -11,13 +11,12 @@ import { basename, join } from "node:path";
 import { stdin, stdout } from "node:process";
 import { createInterface } from "node:readline/promises";
 import { loadConfig } from "../config.js";
-import { kebab } from "../pipeline/writer.js";
+import { REJECTED_DIR, kebab } from "../pipeline/writer.js";
 import * as ui from "../ui/display.js";
 
 // The four typed category dirs hold reviewable notes. `.rejected/`, `archived/`,
 // `projects/`, index.md and log.md are intentionally never walked.
 const CATEGORY_DIRS = ["patterns", "gotchas", "decisions", "tools"] as const;
-const REJECTED_DIR = ".rejected";
 
 export interface ReviewNote {
   filePath: string;

--- a/src/pipeline/writer.test.ts
+++ b/src/pipeline/writer.test.ts
@@ -1,9 +1,16 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Config } from "../config.js";
 import type { DistilledNote, ParsedSession } from "./types.js";
+import { rejectNote } from "../cli/review.js";
 import { VaultWriter } from "./writer.js";
 
 function makeCfg(vaultPath: string): Config {
@@ -154,5 +161,30 @@ describe("VaultWriter write modes", () => {
     const after = readFileSync(notePath!, "utf8");
     expect(after).toContain("verified: true");
     expect(after).toContain("reviewed_at: 2026-05-24T00:00:00.000Z");
+  });
+});
+
+describe("VaultWriter rejection stickiness", () => {
+  let vault: string;
+
+  beforeEach(() => {
+    vault = mkdtempSync(join(tmpdir(), "vir-vault-"));
+  });
+
+  afterEach(() => {
+    rmSync(vault, { recursive: true, force: true });
+  });
+
+  it("does not resurrect a rejected note on re-distill", async () => {
+    const root = join(vault, "vir");
+    const writer = new VaultWriter(makeCfg(vault), null);
+    const [notePath] = await writer.write(makeSession(), makeNote());
+    const rejectedPath = rejectNote(notePath!, root);
+
+    // --full re-distill: same session, same topic, so the same slug.
+    await writer.write(makeSession(), makeNote());
+
+    expect(existsSync(notePath!)).toBe(false);
+    expect(existsSync(rejectedPath)).toBe(true);
   });
 });

--- a/src/pipeline/writer.ts
+++ b/src/pipeline/writer.ts
@@ -40,6 +40,10 @@ import {
 } from "./composer.js";
 import { kebab, makeSlug } from "./slug.js";
 
+// Rejected notes are moved here by `vir review`, never deleted. Shared with
+// cli/review.ts so the two sides can't drift apart.
+export const REJECTED_DIR = ".rejected";
+
 const CATEGORY_DIR: Record<Category, string> = {
   pattern: "patterns",
   gotcha: "gotchas",
@@ -95,6 +99,14 @@ export class VaultWriter {
     const subDir = CATEGORY_DIR[classification.category];
     const relPath = join(subDir, `${slug}.md`);
     const fullPath = join(this.root, relPath);
+
+    // `vir review` rejects by MOVING the note into `.rejected/`, so the category
+    // path no longer exists and preservedReviewFields() below finds nothing to
+    // carry over — a --full re-distill would write the note back as if it had
+    // never been rejected. Rejection is sticky: leave the file where the user
+    // put it, and skip the embedding + index/log work entirely.
+    const rejectedPath = join(this.root, REJECTED_DIR, `${slug}.md`);
+    if (existsSync(rejectedPath)) return [rejectedPath];
 
     // themes is a fresh classify signal but isn't a DB column, so a rewrite-only
     // pass carries none — fall back to the existing note's themes block then,


### PR DESCRIPTION
Closes #9.

## The bug

`vir review` rejects a note by **moving** it into `.rejected/` (`review.ts:117`). `preservedReviewFields()` carries a review verdict across a rewrite by reading the **destination** path (`writer.ts:438`) — which, for a rejected note, no longer exists. So a `--full` re-distill found no verdict to preserve and wrote the note straight back into its category dir, as if it had never been rejected.

`rejected_at` was in that function's `keep` list all along. It just never had a file to be read from.

## The fix

`write()` checks `.rejected/<slug>.md` before doing any work and returns that path untouched when it exists. The slug is `makeSlug(topic, sessionId)`, so a re-distill of the same session resolves to the same filename — the check is exact, not a heuristic. The note stays where the user put it, and the embedding call plus the index and log appends are skipped for a note nobody wants.

`vir reconcile` and rewrite-only runs go through the same `write()`, so one guard covers all three paths.

`REJECTED_DIR` moves to `writer.ts` and `review.ts` imports it. The literal was declared in both files — the same drift that produced the slug-helper bug in `docs/bug-hunt-2026-07.md` #1.

## Verification

Written test-first. The test failed with the note resurrected in the category dir (`existsSync` → `true`, expected `false`) — the bug exactly — before the guard existed.

- 535 tests pass, 50 files
- `tsc --noEmit` clean
- The test drives the real `rejectNote()` rather than hand-placing a file, so it pins the actual write/reject contract

Test count bumped 534 → 535 in the README badge, the status table, and `site/src/consts.ts`.

## Notes for the reviewer

- **The site suite is unverified locally.** `site/node_modules` is empty in my worktree, so all 4 site test files fail to transform. Confirmed pre-existing by reverting the `consts.ts` edit and re-running — identical failure. CI installs `site/` separately and will cover it.
- **No CHANGELOG entry.** The file has no `Unreleased` section and I didn't want to invent a version number. This needs a line under whatever ships next.