### PR TITLE
fix: resolve a note by session id, not by its current title

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ developer-tools, mcp, local-first, cross-platform, llm-wiki
   <a href="https://www.npmjs.com/package/@djolex999/vir-cli"><img src="https://img.shields.io/npm/v/@djolex999/vir-cli?color=7c6af7&label=npm" alt="npm version"></a>
   <a href="https://www.npmjs.com/package/@djolex999/vir-cli"><img src="https://img.shields.io/npm/dw/@djolex999/vir-cli?color=4fd1a0" alt="npm downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22d3ee" alt="license"></a>
-  <a href="#project-status"><img src="https://img.shields.io/badge/tests-535%20passing-22c55e" alt="tests"></a>
+  <a href="#project-status"><img src="https://img.shields.io/badge/tests-540%20passing-22c55e" alt="tests"></a>
   <a href="#project-status"><img src="https://img.shields.io/badge/platforms-macOS%20%7C%20Linux-lightgrey" alt="platforms"></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-server-c084fc" alt="mcp"></a>
   <a href="#"><img src="https://img.shields.io/badge/local--first-yes-f59e0b" alt="local-first"></a>
@@ -505,7 +505,7 @@ improvements. Delete it any time; disable it with `"logQueries": false` in
 |                |                                           |
 | -------------- | ----------------------------------------- |
 | Version        | 0.17.2                                    |
-| Tests          | 535 passing                               |
+| Tests          | 540 passing                               |
 | Platforms      | macOS (launchd), Linux (systemd/cron)     |
 | Node           | 20+                                       |
 | First-run cost | $1 to $5 (Kie.ai optional, ~72% cheaper)  |

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -23,14 +23,14 @@ export const INSTALL_CMD = `npm install -g ${NPM_PKG}`;
 //   transcriptsSeen  — rows in the sessions table
 //   transcriptsNoise — skip_reason in (workflow-transcript, agent-transcript, sidechain-transcript)
 //   transcriptsNotes — skipped=0 and note_paths != '[]'
-//   tests            — `npm test` at the repo root (535 CLI; the site's 18 are separate)
+//   tests            — `npm test` at the repo root (540 CLI; the site's 18 are separate)
 //   cost*            — `vir cost --since 180d`
 export const NUMBERS = {
   sessionsRescued: 396,
   transcriptsSeen: 1429,
   transcriptsNoise: 601,
   transcriptsNotes: 411,
-  tests: 535 as number | null,
+  tests: 540 as number | null,
   costWindow: "six months",
   costSessions: 296,
   costTotal: "$22.23" as string | null,

--- a/src/pipeline/slug.ts
+++ b/src/pipeline/slug.ts
@@ -16,3 +16,10 @@ export function makeSlug(topic: string, sessionId: string): string {
   const suffix = sessionId.slice(0, 8);
   return base.length > 0 ? `${base}-${suffix}` : `note-${suffix}`;
 }
+
+// The half of a note filename that identifies its session. MUST stay in step
+// with the suffix makeSlug appends: callers resolve an existing note by this
+// when the topic half has changed underneath them.
+export function sessionSuffix(sessionId: string): string {
+  return sessionId.slice(0, 8);
+}

--- a/src/pipeline/writer.test.ts
+++ b/src/pipeline/writer.test.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Config } from "../config.js";
 import type { DistilledNote, ParsedSession } from "./types.js";
-import { rejectNote } from "../cli/review.js";
+import { approveNote, rejectNote } from "../cli/review.js";
 import { VaultWriter } from "./writer.js";
 
 function makeCfg(vaultPath: string): Config {
@@ -35,11 +35,11 @@ function makeCfg(vaultPath: string): Config {
   };
 }
 
-function makeSession(): ParsedSession {
+function makeSession(sessionId = "abc12345"): ParsedSession {
   return {
-    path: "/x/abc12345.jsonl",
+    path: `/x/${sessionId}.jsonl`,
     hash: "",
-    sessionId: "abc12345",
+    sessionId,
     projectSlug: "demo",
     startedAt: "2026-05-01T10:00:00.000Z",
     endedAt: null,
@@ -53,11 +53,15 @@ function makeSession(): ParsedSession {
   };
 }
 
-function makeNote(themes: string[] = []): DistilledNote {
+function makeNote(
+  themes: string[] = [],
+  topic = "test topic",
+  category: DistilledNote["classification"]["category"] = "pattern",
+): DistilledNote {
   return {
     classification: {
-      category: "pattern",
-      topic: "test topic",
+      category,
+      topic,
       project: "demo",
       confidence: 0.9,
       themes,
@@ -186,5 +190,92 @@ describe("VaultWriter rejection stickiness", () => {
 
     expect(existsSync(notePath!)).toBe(false);
     expect(existsSync(rejectedPath)).toBe(true);
+  });
+});
+
+// A note's filename comes from its topic, but its identity is the session id.
+// The distiller retitles deliberately (0.9.1), so every one of these cases is
+// a normal re-distill, not an exotic edge.
+describe("VaultWriter session-id identity", () => {
+  let vault: string;
+  let root: string;
+
+  beforeEach(() => {
+    vault = mkdtempSync(join(tmpdir(), "vir-vault-"));
+    root = join(vault, "vir");
+  });
+
+  afterEach(() => {
+    rmSync(vault, { recursive: true, force: true });
+  });
+
+  it("keeps a rejected note rejected when the re-distill retitles it", async () => {
+    const writer = new VaultWriter(makeCfg(vault), null);
+    const [first] = await writer.write(makeSession(), makeNote());
+    rejectNote(first!, root);
+
+    const [after] = await writer.write(
+      makeSession(),
+      makeNote([], "a completely different title"),
+    );
+
+    expect(after).toContain(".rejected");
+    expect(existsSync(join(root, "patterns", "a-completely-different-title-abc12345.md"))).toBe(false);
+  });
+
+  it("moves a retitled note instead of forking a duplicate", async () => {
+    const writer = new VaultWriter(makeCfg(vault), null);
+    const [first] = await writer.write(makeSession(), makeNote());
+
+    const [second] = await writer.write(
+      makeSession(),
+      makeNote([], "renamed topic"),
+    );
+
+    expect(existsSync(second!)).toBe(true);
+    expect(existsSync(first!)).toBe(false);
+  });
+
+  it("preserves the review verdict across a retitle", async () => {
+    const writer = new VaultWriter(makeCfg(vault), null);
+    const [first] = await writer.write(makeSession(), makeNote());
+    approveNote(first!);
+
+    const [second] = await writer.write(
+      makeSession(),
+      makeNote([], "renamed topic"),
+    );
+
+    expect(readFileSync(second!, "utf8")).toContain("verified: true");
+  });
+
+  it("drops the stale index row when a note is retitled", async () => {
+    const writer = new VaultWriter(makeCfg(vault), null);
+    await writer.write(makeSession(), makeNote());
+
+    await writer.write(makeSession(), makeNote([], "renamed topic"));
+
+    const index = readFileSync(join(root, "index.md"), "utf8");
+    expect(index).not.toContain("test-topic-abc12345");
+    expect(index).toContain("renamed-topic-abc12345");
+  });
+
+  // makeSlug truncates the session id to 8 chars, so two distinct sessions can
+  // share a filename suffix. Resolving on the suffix alone would make one
+  // session's note delete the other's.
+  it("does not treat a suffix collision as the same note", async () => {
+    const writer = new VaultWriter(makeCfg(vault), null);
+    const [first] = await writer.write(
+      makeSession("abc12345-1111-4444-8888-aaaaaaaaaaaa"),
+      makeNote([], "first session topic"),
+    );
+
+    const [second] = await writer.write(
+      makeSession("abc12345-2222-4444-8888-bbbbbbbbbbbb"),
+      makeNote([], "second session topic"),
+    );
+
+    expect(existsSync(second!)).toBe(true);
+    expect(existsSync(first!)).toBe(true);
   });
 });

--- a/src/pipeline/writer.ts
+++ b/src/pipeline/writer.ts
@@ -5,9 +5,10 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  rmSync,
   writeFileSync,
 } from "node:fs";
-import { join, relative } from "node:path";
+import { dirname, join, relative } from "node:path";
 import type { Config } from "../config.js";
 import { cosineSimilarity } from "../search/embedder.js";
 import {
@@ -38,7 +39,7 @@ import {
   composeRelPath,
   type ComposedTopic,
 } from "./composer.js";
-import { kebab, makeSlug } from "./slug.js";
+import { kebab, makeSlug, sessionSuffix } from "./slug.js";
 
 // Rejected notes are moved here by `vir review`, never deleted. Shared with
 // cli/review.ts so the two sides can't drift apart.
@@ -100,13 +101,21 @@ export class VaultWriter {
     const relPath = join(subDir, `${slug}.md`);
     const fullPath = join(this.root, relPath);
 
-    // `vir review` rejects by MOVING the note into `.rejected/`, so the category
-    // path no longer exists and preservedReviewFields() below finds nothing to
-    // carry over — a --full re-distill would write the note back as if it had
-    // never been rejected. Rejection is sticky: leave the file where the user
-    // put it, and skip the embedding + index/log work entirely.
-    const rejectedPath = join(this.root, REJECTED_DIR, `${slug}.md`);
-    if (existsSync(rejectedPath)) return [rejectedPath];
+    // The path above is derived from the CURRENT topic, but the distiller
+    // retitles between runs on purpose (0.9.1) — so it can't be used to find
+    // the note this one replaces. Resolve by session id instead.
+    const prior = this.locateBySession(session.sessionId);
+
+    // `vir review` rejects by MOVING the note into `.rejected/`. Rejection is
+    // sticky: leave the file where the user put it, and skip the embedding and
+    // index/log work entirely.
+    if (prior !== null && dirname(prior) === join(this.root, REJECTED_DIR)) {
+      return [prior];
+    }
+
+    // Read carried-over state from where the note actually is, not from where
+    // this run's title says it would go.
+    const priorPath = prior ?? fullPath;
 
     // themes is a fresh classify signal but isn't a DB column, so a rewrite-only
     // pass carries none — fall back to the existing note's themes block then,
@@ -114,7 +123,7 @@ export class VaultWriter {
     const themesLines =
       classification.themes.length > 0
         ? renderThemesLines(classification.themes)
-        : this.preservedThemesBlock(fullPath);
+        : this.preservedThemesBlock(priorPath);
 
     // Obsidian resolves [[bare-kebab-topic]] (what wikilinkRelated emits in
     // OTHER notes' Related sections) to this note only via an alias — the
@@ -133,7 +142,7 @@ export class VaultWriter {
       // A user's review verdict (set by `vir review`) lives in frontmatter, not
       // SQLite — so any rewrite of the file (rewrite-only OR a --full re-distill
       // that re-emits an existing note) would clobber it. Carry it over verbatim.
-      ...this.preservedReviewFields(fullPath),
+      ...this.preservedReviewFields(priorPath),
       "---",
       "",
     ].join("\n");
@@ -162,6 +171,17 @@ export class VaultWriter {
 
     const finalContent = frontmatter + wikilinkHeader + body + "\n";
     writeFileSync(fullPath, finalContent);
+
+    // A retitle or recategorisation lands the note on a new path. Retire the
+    // old file and its index row rather than leaving a stale duplicate behind
+    // — append mode never regenerates index.md, so a dropped row must be
+    // dropped explicitly.
+    if (prior !== null && prior !== fullPath) {
+      rmSync(prior, { force: true });
+      this.dropIndexRow(relative(this.root, prior));
+    }
+    this.noteIndex?.set(sessionSuffix(session.sessionId), fullPath);
+
     if (vec && provider && this.db) {
       try {
         this.db.storeEmbedding(session.sessionId, vec, provider.provenance());
@@ -446,6 +466,78 @@ export class VaultWriter {
   // Read back any review verdict already stamped on an existing note so a
   // rewrite preserves it. Returns the raw frontmatter lines (e.g.
   // `verified: true`) in stable order; [] for a brand-new note or no fields.
+  // A note's filename is `<kebab-topic>-<8-char session>.md`, so the only
+  // stable part is the suffix — the topic half is whatever the distiller chose
+  // that run. Built once per writer and kept current as notes are written; a
+  // full rescan per note would be O(n^2) over a vault with thousands of them.
+  private noteIndex: Map<string, string> | null = null;
+
+  private buildNoteIndex(): Map<string, string> {
+    const idx = new Map<string, string>();
+    // `.rejected/` is scanned last so it wins: a rejection is the authoritative
+    // location for its session, even if a stale category copy exists.
+    for (const sub of [...Object.values(CATEGORY_DIR), REJECTED_DIR]) {
+      const dir = join(this.root, sub);
+      if (!existsSync(dir)) continue;
+      for (const name of readdirSync(dir)) {
+        if (!name.endsWith(".md")) continue;
+        const suffix = name.slice(0, -".md".length).split("-").pop();
+        if (suffix !== undefined && suffix.length > 0) {
+          idx.set(suffix, join(dir, name));
+        }
+      }
+    }
+    return idx;
+  }
+
+  // Confirm a suffix match really is this session. makeSlug truncates the id to
+  // 8 chars, so two sessions can collide — and since a match here authorises
+  // deleting the old file, the suffix is only an index hint. The full id in
+  // frontmatter is the authority.
+  private belongsToSession(notePath: string, sessionId: string): boolean {
+    try {
+      const m = readFileSync(notePath, "utf8").match(/^session_id:\s*(.+)$/m);
+      return m?.[1]?.trim() === sessionId;
+    } catch {
+      return false;
+    }
+  }
+
+  private locateBySession(sessionId: string): string | null {
+    this.noteIndex ??= this.buildNoteIndex();
+    const suffix = sessionSuffix(sessionId);
+    const hit = this.noteIndex.get(suffix);
+    if (hit !== undefined && existsSync(hit)) {
+      return this.belongsToSession(hit, sessionId) ? hit : null;
+    }
+    if (hit === undefined) return null;
+    // The cached path is gone: `vir review` moves notes into `.rejected/`
+    // between runs, so an entry recorded earlier can point nowhere. Rebuild
+    // once and retry — but only on a stale hit, never on a miss, or every
+    // genuinely-new note in a batch would trigger a full rescan.
+    this.noteIndex = this.buildNoteIndex();
+    const rebuilt = this.noteIndex.get(suffix);
+    if (rebuilt === undefined) return null;
+    return this.belongsToSession(rebuilt, sessionId) ? rebuilt : null;
+  }
+
+  // Drop the index.md row pointing at a path that no longer exists. Rows are
+  // matched on the wikilink target, which is unique per note.
+  private dropIndexRow(relPath: string): void {
+    const p = join(this.root, "index.md");
+    if (!existsSync(p)) return;
+    const marker = `[[${relPath.replace(/\.md$/, "")}|`;
+    const current = readFileSync(p, "utf8");
+    if (!current.includes(marker)) return;
+    writeFileSync(
+      p,
+      current
+        .split("\n")
+        .filter((line) => !line.includes(marker))
+        .join("\n"),
+    );
+  }
+
   private preservedReviewFields(fullPath: string): string[] {
     if (!existsSync(fullPath)) return [];
     let content: string;


### PR DESCRIPTION
Closes bug-hunt #12. Completes #9, which 0.17.2 only half-fixed.

## Root cause

A note's path is `makeSlug(topic, sessionId)` — built from the **topic**, which the distiller changes between runs on purpose (0.9.1 retitles deliberately). The path was therefore never identity; the session id is. Every consumer that recomputed the path from the current topic quietly missed the note it was meant to be updating:

- `preservedReviewFields()` read the *new* path, so a retitle dropped `verified` / `reviewed_at` and the +0.2 retrieval boost with it
- the old note stayed on disk as a duplicate
- the `.rejected/` guard I shipped in 0.17.2 keyed off the current slug too, so it only ever covered the same-topic case — retitle and a rejected note came straight back

Three symptoms, one cause.

## The fix

`locateBySession()` indexes the vault by the filename's session suffix, built once per writer instance and kept current as notes are written (a rescan per note would be O(n²) on a vault with thousands). `.rejected/` is scanned last so it wins — a rejection is the authoritative location for its session.

A hit is then confirmed against the full `session_id` in frontmatter before it's used. `makeSlug` truncates the id to 8 characters, so two sessions *can* share a suffix, and a match here authorises deleting a file. The suffix is an index hint; the full id is the authority. I found this by writing the collision test — the first version of this patch deleted the colliding note, and the test caught it before it left my machine. A collision now degrades to an orphaned duplicate, never a deletion.

`write()` reads carried-over verdict and themes from the note's actual location, and on a retitle removes the old file and drops its `index.md` row — append mode never regenerates the index, so a stale row has to go explicitly.

The cache also revalidates a stale hit: `vir review` moves notes into `.rejected/` between runs, so an entry recorded earlier can point nowhere. It rebuilds only on a stale hit, never on a miss, so a batch of genuinely-new notes doesn't trigger a rescan each.

## Tests

Five, each written first and watched fail for the right reason:

- a rejected note stays rejected when the re-distill retitles it
- a retitle moves the note instead of forking a duplicate
- a retitle preserves the review verdict
- a retitle drops the stale index row
- a suffix collision is not treated as the same note

540 pass, 50 files. `tsc --noEmit` clean.

## Deliberately out of scope

- **`archived/` (dedupe) is not indexed.** A merged-away note being re-created by a re-distill is the same shape of problem, but the right answer there depends on what a merge is supposed to mean for the loser's session — it wants its own decision, not a silent extension of this one.
- Articles, PDFs and topic pages are keyed by URL/file slug rather than session id and are untouched.

## Note for the reviewer

Same as last time: `site/node_modules` is empty in my worktree so I can't run the site suite locally; CI covers it. The only site change is the test count in `consts.ts`.