### PR TITLE
fix: four findings from the July audit backlog (#17, #13, #14, #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ developer-tools, mcp, local-first, cross-platform, llm-wiki
   <a href="https://www.npmjs.com/package/@djolex999/vir-cli"><img src="https://img.shields.io/npm/v/@djolex999/vir-cli?color=7c6af7&label=npm" alt="npm version"></a>
   <a href="https://www.npmjs.com/package/@djolex999/vir-cli"><img src="https://img.shields.io/npm/dw/@djolex999/vir-cli?color=4fd1a0" alt="npm downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22d3ee" alt="license"></a>
-  <a href="#project-status"><img src="https://img.shields.io/badge/tests-540%20passing-22c55e" alt="tests"></a>
+  <a href="#project-status"><img src="https://img.shields.io/badge/tests-557%20passing-22c55e" alt="tests"></a>
   <a href="#project-status"><img src="https://img.shields.io/badge/platforms-macOS%20%7C%20Linux-lightgrey" alt="platforms"></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-server-c084fc" alt="mcp"></a>
   <a href="#"><img src="https://img.shields.io/badge/local--first-yes-f59e0b" alt="local-first"></a>
@@ -505,7 +505,7 @@ improvements. Delete it any time; disable it with `"logQueries": false` in
 |                |                                           |
 | -------------- | ----------------------------------------- |
 | Version        | 0.17.3                                    |
-| Tests          | 540 passing                               |
+| Tests          | 557 passing                               |
 | Platforms      | macOS (launchd), Linux (systemd/cron)     |
 | Node           | 20+                                       |
 | First-run cost | $1 to $5 (Kie.ai optional, ~72% cheaper)  |

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -23,14 +23,14 @@ export const INSTALL_CMD = `npm install -g ${NPM_PKG}`;
 //   transcriptsSeen  — rows in the sessions table
 //   transcriptsNoise — skip_reason in (workflow-transcript, agent-transcript, sidechain-transcript)
 //   transcriptsNotes — skipped=0 and note_paths != '[]'
-//   tests            — `npm test` at the repo root (540 CLI; the site's 18 are separate)
+//   tests            — `npm test` at the repo root (557 CLI; the site's 18 are separate)
 //   cost*            — `vir cost --since 180d`
 export const NUMBERS = {
   sessionsRescued: 396,
   transcriptsSeen: 1429,
   transcriptsNoise: 601,
   transcriptsNotes: 411,
-  tests: 540 as number | null,
+  tests: 557 as number | null,
   costWindow: "six months",
   costSessions: 296,
   costTotal: "$22.23" as string | null,

--- a/src/claude/updater.test.ts
+++ b/src/claude/updater.test.ts
@@ -1,0 +1,118 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { applyPlan, VIR_END, VIR_START, type PlanItem } from "./updater.js";
+
+const BLOCK = `${VIR_START}\nfresh vir content\n${VIR_END}`;
+
+function plan(target: string): PlanItem {
+  return {
+    target,
+    exists: true,
+    hasBlock: true,
+    lastUpdated: null,
+    newBlock: BLOCK,
+    diff: { added: 0, removed: 0 } as PlanItem["diff"],
+    scope: "global",
+  };
+}
+
+// applyPlan rewrites a file the user owns and edits by hand. Every case below
+// is a file a human could plausibly produce, and the failure mode for three of
+// them was silent destruction of their prose.
+describe("applyPlan marker handling", () => {
+  let dir: string;
+  let target: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vir-claudemd-"));
+    target = join(dir, "CLAUDE.md");
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("replaces a well-formed block in place", () => {
+    writeFileSync(target, `intro\n\n${VIR_START}\nold\n${VIR_END}\n\noutro\n`);
+
+    expect(applyPlan(plan(target)).ok).toBe(true);
+
+    const out = readFileSync(target, "utf8");
+    expect(out).toContain("intro");
+    expect(out).toContain("outro");
+    expect(out).toContain("fresh vir content");
+    expect(out).not.toContain("old");
+  });
+
+  it("appends when the file has no block at all", () => {
+    writeFileSync(target, "just my notes\n");
+
+    expect(applyPlan(plan(target)).ok).toBe(true);
+    expect(readFileSync(target, "utf8")).toContain("fresh vir content");
+  });
+
+  it("refuses an orphan START rather than appending a second block", () => {
+    // Appending here is what sets up the deletion: the NEXT sync would slice
+    // from this orphan START to the appended block's END, taking the user's
+    // prose in between with it.
+    const before = `notes\n${VIR_START}\nhand-mangled\n\nmore of my prose\n`;
+    writeFileSync(target, before);
+
+    const result = applyPlan(plan(target));
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/marker/i);
+    expect(readFileSync(target, "utf8")).toBe(before);
+  });
+
+  it("refuses when END comes before START instead of duplicating the gap", () => {
+    const before = `notes\n${VIR_END}\nmy prose\n${VIR_START}\ntail\n`;
+    writeFileSync(target, before);
+
+    const result = applyPlan(plan(target));
+
+    expect(result.ok).toBe(false);
+    expect(readFileSync(target, "utf8")).toBe(before);
+  });
+
+  it("collapses duplicate blocks instead of leaving the second behind", () => {
+    writeFileSync(
+      target,
+      `top\n${VIR_START}\nfirst\n${VIR_END}\nmiddle\n${VIR_START}\nsecond\n${VIR_END}\nend\n`,
+    );
+
+    expect(applyPlan(plan(target)).ok).toBe(true);
+
+    const out = readFileSync(target, "utf8");
+    expect(out.match(new RegExp(VIR_START, "g"))).toHaveLength(1);
+    expect(out).toContain("top");
+    expect(out).toContain("middle");
+    expect(out).toContain("end");
+    expect(out).not.toContain("second");
+  });
+
+  it("ignores markers inside a fenced code block", () => {
+    // A CLAUDE.md that documents vir's own markers must not be edited at them.
+    const before = [
+      "here is how vir marks its block:",
+      "",
+      "```markdown",
+      VIR_START,
+      "example",
+      VIR_END,
+      "```",
+      "",
+    ].join("\n");
+    writeFileSync(target, before);
+
+    expect(applyPlan(plan(target)).ok).toBe(true);
+
+    const out = readFileSync(target, "utf8");
+    expect(out).toContain("```markdown");
+    expect(out).toContain("example");
+    expect(out).toContain("fresh vir content");
+    // The fenced example survives untouched and the real block was appended.
+    expect(out.indexOf("fresh vir content")).toBeGreaterThan(out.indexOf("```"));
+  });
+});

--- a/src/claude/updater.ts
+++ b/src/claude/updater.ts
@@ -237,30 +237,96 @@ function computeDiff(old: Entry[], next: Entry[]): DiffResult {
   return { added, removed, upgraded, unchanged };
 }
 
-export function applyPlan(plan: PlanItem): boolean {
-  if (!plan.exists) return false;
+export interface ApplyResult {
+  ok: boolean;
+  reason?: string;
+}
+
+// Marker offsets that are REAL — i.e. not inside a fenced code block. A
+// CLAUDE.md may legitimately document vir's own markers (this repo's docs do),
+// and editing the file at an example would corrupt it.
+function markerOffsets(raw: string): { starts: number[]; ends: number[] } {
+  const starts: number[] = [];
+  const ends: number[] = [];
+  let offset = 0;
+  let fenced = false;
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (t.startsWith("```") || t.startsWith("~~~")) {
+      fenced = !fenced;
+    } else if (!fenced) {
+      if (t === VIR_START) starts.push(offset);
+      else if (t === VIR_END) ends.push(offset);
+    }
+    offset += line.length + 1;
+  }
+  return { starts, ends };
+}
+
+// Pair markers into complete blocks, walking forward: a START claims the first
+// END after it. Returns null when anything is left unmatched — an orphan START
+// from a hand-edit, or an END before any START.
+function pairBlocks(
+  starts: number[],
+  ends: number[],
+): Array<{ from: number; to: number }> | null {
+  const blocks: Array<{ from: number; to: number }> = [];
+  let ei = 0;
+  for (const start of starts) {
+    while (ei < ends.length && ends[ei]! < start) return null; // END before START
+    if (ei >= ends.length) return null; // START with no END after it
+    blocks.push({ from: start, to: ends[ei]! + VIR_END.length });
+    ei += 1;
+  }
+  if (ei !== ends.length) return null; // trailing unmatched END
+  return blocks;
+}
+
+export function applyPlan(plan: PlanItem): ApplyResult {
+  if (!plan.exists) return { ok: false, reason: "file does not exist" };
   let raw: string;
   try {
     raw = readFileSync(plan.target, "utf8");
   } catch {
-    return false;
+    return { ok: false, reason: "could not read file" };
   }
 
+  const { starts, ends } = markerOffsets(raw);
   let updated: string;
-  if (raw.includes(VIR_START) && raw.includes(VIR_END)) {
-    const start = raw.indexOf(VIR_START);
-    const end = raw.indexOf(VIR_END) + VIR_END.length;
-    updated = raw.slice(0, start) + plan.newBlock + raw.slice(end);
-  } else {
+
+  if (starts.length === 0 && ends.length === 0) {
     const sep = raw.endsWith("\n") ? "\n" : "\n\n";
     updated = raw + sep + plan.newBlock + "\n";
+  } else {
+    const blocks = pairBlocks(starts, ends);
+    // Unbalanced markers mean a hand-edit went wrong. Appending here is what
+    // made this destructive: the NEXT sync would slice from the orphan marker
+    // to the appended block's END and delete everything the user wrote in
+    // between. Refuse, say so, and let them fix their own file.
+    if (blocks === null || blocks.length === 0) {
+      return {
+        ok: false,
+        reason: `unbalanced ${VIR_START} / ${VIR_END} markers — fix them by hand, nothing was written`,
+      };
+    }
+    // Replace the first block; drop any later ones. Splice back-to-front so
+    // earlier offsets stay valid. Later blocks are entirely vir-owned, so
+    // removing them takes none of the user's content.
+    updated = raw;
+    for (let i = blocks.length - 1; i >= 1; i -= 1) {
+      const b = blocks[i]!;
+      updated = updated.slice(0, b.from) + updated.slice(b.to);
+    }
+    const first = blocks[0]!;
+    updated =
+      updated.slice(0, first.from) + plan.newBlock + updated.slice(first.to);
   }
 
   try {
     writeFileSync(plan.target, updated);
-    return true;
+    return { ok: true };
   } catch {
-    return false;
+    return { ok: false, reason: "could not write file" };
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -615,10 +615,14 @@ program
             ui.row(ui.warn(ui.WARN_GLYPH), ui.text(`skipped ${collapseHome(p.target)}`));
             continue;
           }
-          const ok = applyPlan(p);
+          const result = applyPlan(p);
           ui.row(
-            ok ? ui.success(ui.CHECK) : ui.errorColor(ui.CROSS),
-            ui.text(collapseHome(p.target)),
+            result.ok ? ui.success(ui.CHECK) : ui.errorColor(ui.CROSS),
+            ui.text(
+              result.ok || result.reason === undefined
+                ? collapseHome(p.target)
+                : `${collapseHome(p.target)} — ${result.reason}`,
+            ),
           );
         }
       } finally {

--- a/src/cost/pricing.test.ts
+++ b/src/cost/pricing.test.ts
@@ -100,3 +100,23 @@ describe("claude-sonnet-5 pricing (default provider/model as of 0.14.0)", () => 
     expect(computeCost("anthropic", "claude-sonnet-5", 100_000, 2_000)).toBeGreaterThan(0);
   });
 });
+
+// A model absent from DEFAULT_PRICING is exactly the case a config override
+// exists for: a new model id ships before the table catches up. Returning null
+// there logs the run at $0 — silently, which is the failure mode cost logging
+// is supposed to prevent.
+describe("resolvePricing with overrides for an unknown model", () => {
+  it("uses a complete override for a model absent from the default table", () => {
+    const p = resolvePricing("anthropic", "claude-opus-9", {
+      anthropic: { "claude-opus-9": { inputPer1M: 15, outputPer1M: 75 } },
+    });
+    expect(p).toEqual({ inputPer1M: 15, outputPer1M: 75 });
+  });
+
+  it("still returns null for a partial override it cannot complete", () => {
+    const p = resolvePricing("anthropic", "claude-opus-9", {
+      anthropic: { "claude-opus-9": { inputPer1M: 15 } },
+    });
+    expect(p).toBeNull();
+  });
+});

--- a/src/cost/pricing.ts
+++ b/src/cost/pricing.ts
@@ -68,7 +68,21 @@ export function resolvePricing(
 ): ModelPricing | null {
   const table = DEFAULT_PRICING[provider];
   const baseKey = findTableKey(table, model);
-  if (baseKey === undefined) return null;
+  if (baseKey === undefined) {
+    // No posted rate for this model. A config override is exactly the escape
+    // hatch for that case — a new model id shipping before the table catches
+    // up — so consult it before giving up. Returning null here regardless is
+    // how a configured price silently logged the run at $0.
+    // Only a COMPLETE override can stand alone: there is no base to patch, and
+    // half a price is a wrong price, not a partial one.
+    const patch = overrides?.[provider]?.[
+      findOverrideKey(overrides[provider] ?? {}, model) ?? ""
+    ];
+    if (patch?.inputPer1M !== undefined && patch.outputPer1M !== undefined) {
+      return { inputPer1M: patch.inputPer1M, outputPer1M: patch.outputPer1M };
+    }
+    return null;
+  }
 
   // Non-null assertion is safe: baseKey came from Object.keys(table)
   const base: ModelPricing = { ...table[baseKey]! };

--- a/src/mcp/install.ts
+++ b/src/mcp/install.ts
@@ -9,13 +9,9 @@
  */
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import * as ui from "../ui/display.js";
+import { VIR_TOOLS as TOOLS } from "./tools.js";
 
-const TOOLS = [
-  "vir_query",
-  "vir_status",
-  "vir_recent_notes",
-  "vir_project_summary",
-] as const;
+
 
 function runClaude(args: string[]): SpawnSyncReturns<string> {
   return spawnSync("claude", args, { encoding: "utf8" });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -28,6 +28,7 @@ import { join } from "node:path";
 import { exit } from "node:process";
 import { z } from "zod";
 import { STATE_PATH, type Config } from "../config.js";
+import { readVirVersion } from "../version.js";
 import { composeSlug, TOPICS_SUBDIR } from "../pipeline/composer.js";
 import type { Category } from "../pipeline/types.js";
 import { kebab, makeSlug } from "../pipeline/writer.js";
@@ -215,7 +216,7 @@ export async function runMcpServer(cfg: Config): Promise<void> {
     exit(1);
   }
 
-  const server = new McpServer({ name: "vir", version: "0.1.1" });
+  const server = new McpServer({ name: "vir", version: readVirVersion() });
 
   server.registerTool(
     "vir_query",

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { readVirVersion } from "../version.js";
+import { VIR_TOOLS } from "./tools.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+describe("MCP tool advertisement", () => {
+  // `vir mcp install` printed a hardcoded list that had drifted two tools
+  // behind the server. Pin the two together against the source of truth so a
+  // new tool can't ship half-announced.
+  it("advertises exactly the tools the server registers", () => {
+    const src = readFileSync(join(here, "server.ts"), "utf8");
+    const registered = [
+      ...src.matchAll(/registerTool\(\s*"(vir_[a-z_]+)"/g),
+    ].map((m) => m[1]!);
+
+    expect(registered.length).toBeGreaterThan(0);
+    expect([...registered].sort()).toEqual([...VIR_TOOLS].sort());
+  });
+});
+
+describe("readVirVersion", () => {
+  it("is what the MCP server reports to clients", () => {
+    const src = readFileSync(join(here, "server.ts"), "utf8");
+    const init = src.match(/new McpServer\(\{[^}]*\}\)/)?.[0] ?? "";
+    expect(init).toContain("readVirVersion()");
+    expect(init).not.toMatch(/version:\s*"/);
+  });
+
+  it("reports the package version rather than a hardcoded one", () => {
+    const pkg = JSON.parse(
+      readFileSync(join(here, "..", "..", "package.json"), "utf8"),
+    ) as { version: string };
+    expect(readVirVersion()).toBe(pkg.version);
+  });
+});

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,0 +1,11 @@
+// The tools `vir mcp` exposes. `vir mcp install` prints this list and the
+// server registers exactly these — a test pins the two together, because the
+// printed list had quietly drifted two tools behind the server.
+export const VIR_TOOLS = [
+  "vir_query",
+  "vir_status",
+  "vir_recent_notes",
+  "vir_recent_articles",
+  "vir_project_summary",
+  "vir_compose",
+] as const;

--- a/src/pipeline/distiller.test.ts
+++ b/src/pipeline/distiller.test.ts
@@ -7,6 +7,8 @@ import {
   KieTimeoutError,
   kieResponseError,
   maybeAnthropicClient,
+  ClassifyParseError,
+  Distiller,
   parseClassification,
   selectDistillModel,
 } from "./distiller.js";
@@ -270,5 +272,72 @@ describe("callKie timeout", () => {
       }),
     ).rejects.toBeInstanceOf(KieTimeoutError);
     expect(Date.now() - start).toBeLessThan(2000);
+  });
+});
+
+// A garbled classify response and a genuinely uninteresting session both ended
+// up as confidence 0 — and run.ts records BOTH as skipped with the current
+// hash. `vir reconcile` only targets skipped = 0, so one transient formatting
+// glitch dropped a session's knowledge with no recovery path. The two have to
+// be distinguishable.
+describe("unparseable classify responses are transient, not a verdict", () => {
+  const cfg = {
+    provider: "claude-cli",
+    models: { classify: "claude-haiku-4-5-20251001", distill: "claude-sonnet-4-6" },
+  } as unknown as Config;
+
+  const session = {
+    sessionId: "abc12345",
+    projectSlug: "demo",
+    rawSummary: "",
+  } as unknown as Parameters<Distiller["run"]>[0];
+
+  class StubDistiller extends Distiller {
+    constructor(private readonly stub: Classification) {
+      super(cfg);
+    }
+    override async classify(): Promise<Classification> {
+      return this.stub;
+    }
+  }
+
+  it("marks a response with no JSON at all as unparsed", () => {
+    expect(parseClassification("I'm sorry, I can't do that", "vir").unparsed).toBe(true);
+  });
+
+  it("marks malformed JSON as unparsed", () => {
+    expect(parseClassification('{"category": "pattern", ', "vir").unparsed).toBe(true);
+  });
+
+  it("does not mark a well-formed low-confidence verdict as unparsed", () => {
+    const c = parseClassification(
+      '{"category":"pattern","topic":"x","project":"vir","confidence":0.2}',
+      "vir",
+    );
+    expect(c.unparsed).toBeFalsy();
+    expect(c.confidence).toBe(0.2);
+  });
+
+  it("run() throws on an unparsed classification so the session is retryable", async () => {
+    const d = new StubDistiller({
+      category: "pattern",
+      topic: "unknown",
+      project: "vir",
+      confidence: 0,
+      themes: [],
+      unparsed: true,
+    });
+    await expect(d.run(session, "", "")).rejects.toThrow(ClassifyParseError);
+  });
+
+  it("run() still returns null for a real low-confidence verdict", async () => {
+    const d = new StubDistiller({
+      category: "pattern",
+      topic: "a real but dull topic",
+      project: "vir",
+      confidence: 0.2,
+      themes: [],
+    });
+    await expect(d.run(session, "", "")).resolves.toBeNull();
   });
 });

--- a/src/pipeline/distiller.ts
+++ b/src/pipeline/distiller.ts
@@ -382,6 +382,22 @@ export async function probeProvider(
   await Promise.race([probe, timeout]);
 }
 
+// The model's classify response could not be parsed. Thrown rather than
+// folded into a confidence-0 verdict, because run.ts treats the two
+// oppositely: a thrown error goes through recordError (skipped = 0, error set,
+// attempts + 1) so `vir reconcile` retries it and MAX_DISTILL_ATTEMPTS bounds
+// the spend, while a low-confidence verdict is recorded as skipped and never
+// looked at again. One transient formatting glitch used to take the second
+// path and drop the session's knowledge permanently.
+export class ClassifyParseError extends Error {
+  constructor(sessionId: string) {
+    super(
+      `classify response for ${sessionId} could not be parsed — retryable, not a verdict`,
+    );
+    this.name = "ClassifyParseError";
+  }
+}
+
 export class Distiller {
   private client: Anthropic | null;
   private cfg: Config;
@@ -491,6 +507,7 @@ ${scrubbedContent}`;
     scrubbedContent: string,
   ): Promise<DistilledNote | null> {
     const cls = await this.classify(session, scrubbedSummary);
+    if (cls.unparsed) throw new ClassifyParseError(session.sessionId);
     if (cls.confidence <= 0.6) return null;
     // Hybrid routing decides here, after classify, on the post-filter distill
     // input. The chosen model flows into callLLM and lands in cost.log.
@@ -598,6 +615,7 @@ export function parseClassification(
       project: fallbackProject,
       confidence: 0,
       themes: [],
+      unparsed: true,
     };
   }
   let obj: Record<string, unknown>;
@@ -610,6 +628,7 @@ export function parseClassification(
       project: fallbackProject,
       confidence: 0,
       themes: [],
+      unparsed: true,
     };
   }
   const rawCat = typeof obj.category === "string" ? obj.category : "pattern";

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -49,6 +49,12 @@ export interface Classification {
   // surfacing multi-theme dilution (a grab-bag session names only one in `topic`)
   // — written to note frontmatter, not used by retrieval. Empty when none.
   themes: string[];
+
+  // Set only when the model's response could not be parsed at all. Without it
+  // a formatting glitch is indistinguishable from a genuine confidence-0
+  // verdict — and the two deserve opposite treatment: one is transient and
+  // must stay retryable, the other is an answer.
+  unparsed?: true;
 }
 
 export interface DistilledNote {

--- a/src/state/db.test.ts
+++ b/src/state/db.test.ts
@@ -564,3 +564,43 @@ describe("embedding model provenance", () => {
     db.close();
   });
 });
+
+// The read-only MCP path deliberately skips migrations (they are writes), so a
+// DB that upgraded but never had a writable pass still carries the ORIGINAL
+// sessions schema. getStats names six migration-added columns; on such a DB
+// SQLite raises "no such column" and the whole vir_status tool dies.
+describe("StateDb.getStats on a pre-migration schema", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vir-db-old-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns empty stats instead of throwing", () => {
+    const path = join(dir, "vir.db");
+    const raw = new Database(path);
+    raw.exec(`
+      CREATE TABLE sessions (
+        path TEXT PRIMARY KEY,
+        hash TEXT NOT NULL,
+        processed_at TEXT NOT NULL,
+        skipped INTEGER NOT NULL DEFAULT 0,
+        note_paths TEXT NOT NULL DEFAULT '[]',
+        error TEXT
+      );
+    `);
+    raw.close();
+
+    const db = new StateDb(path, { readonly: true });
+    try {
+      const stats = db.getStats();
+      expect(stats.total).toBe(0);
+      expect(stats.oldestNote).toBe("");
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -367,15 +367,26 @@ export class StateDb {
   // True when `table` carries the provenance columns. The read-only MCP path
   // skips migrations, so an upgraded-but-never-written DB may lack them; read
   // paths must degrade to legacy provenance instead of erroring.
-  private provenanceCache = new Map<string, boolean>();
-  private hasProvenance(table: string): boolean {
-    const cached = this.provenanceCache.get(table);
+  private columnCache = new Map<string, Set<string>>();
+  private columnsOf(table: string): Set<string> {
+    const cached = this.columnCache.get(table);
     if (cached !== undefined) return cached;
-    const has = (
-      this.db.prepare(`PRAGMA table_info(${table})`).all() as ColumnInfo[]
-    ).some((r) => r.name === "embedding_model");
-    this.provenanceCache.set(table, has);
-    return has;
+    let cols: Set<string>;
+    try {
+      cols = new Set(
+        (
+          this.db.prepare(`PRAGMA table_info(${table})`).all() as ColumnInfo[]
+        ).map((r) => r.name),
+      );
+    } catch {
+      cols = new Set();
+    }
+    this.columnCache.set(table, cols);
+    return cols;
+  }
+
+  private hasProvenance(table: string): boolean {
+    return this.columnsOf(table).has("embedding_model");
   }
 
   getByPath(path: string): SessionRow | undefined {
@@ -681,17 +692,37 @@ export class StateDb {
     };
   }
 
+  // Every column below arrived in a migration, and the read-only path skips
+  // migrations — so an upgraded-but-never-written DB has none of them and the
+  // query dies with "no such column", taking the whole vir_status tool with
+  // it. No columns means no distilled rows to count: degrade to empty stats,
+  // which is what the aggregation below produces from zero rows anyway.
+  private static readonly STATS_COLUMNS = [
+    "category",
+    "project",
+    "confidence",
+    "started_at",
+    "content",
+    "archived",
+  ];
+
   getStats(): KnowledgeStats {
-    const rows = this.db
-      .prepare(
-        `SELECT category, project, confidence, started_at
+    const cols = this.columnsOf("sessions");
+    const ready = StateDb.STATS_COLUMNS.every((c) => cols.has(c));
+    const rows = (
+      ready
+        ? this.db
+            .prepare(
+              `SELECT category, project, confidence, started_at
          FROM sessions
          WHERE skipped = 0
            AND error IS NULL
            AND content IS NOT NULL
            AND COALESCE(archived, 0) = 0`,
-      )
-      .all() as Array<{
+            )
+            .all()
+        : []
+    ) as Array<{
       category: string | null;
       project: string | null;
       confidence: number | null;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The ONE runtime read of the published version. rootDir is ./src, so
+// package.json can't be imported — and every hand-counted `..` hop to reach it
+// is a chance to drift (the MCP server shipped a hardcoded "0.1.1" for
+// sixteen releases). This module compiles to dist/version.js, so package.json
+// is exactly one level up. Any failure yields "unknown" rather than throwing:
+// nothing here is worth crashing a command over.
+export function readVirVersion(): string {
+  try {
+    const pkgPath = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "package.json",
+    );
+    return (
+      (JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: string })
+        .version ?? "unknown"
+    );
+  } catch {
+    return "unknown";
+  }
+}


### PR DESCRIPTION
Four independent findings from `docs/bug-hunt-2026-07.md`, one commit each. Two lose data, two lie quietly.

## #17 — a garbled classify response buried a session forever

`parseClassification` folded an unparseable response into a confidence-0 verdict. `run.ts` then recorded it as `skipped: true` **with the current hash**, and `vir reconcile` only targets `skipped = 0`. So one transient formatting glitch dropped that session's knowledge with no recovery path — indistinguishable from a session the model had genuinely judged dull.

The two now diverge where the distinction actually exists: `parseClassification` marks its fallback branches `unparsed`, and `run()` throws `ClassifyParseError` instead of returning null. `run.ts`'s existing handler routes that through `recordError` (skipped = 0, error set, attempts + 1), so the session becomes a reconcile target and `MAX_DISTILL_ATTEMPTS` bounds it at 3 consecutive failures. `reconcile`'s own catch already leaves the row untouched for the next pass, so both callers were correct once the throw existed.

A genuine low-confidence verdict is untouched: still null, still skipped, still never retried. That one is an answer, not an accident.

## #13 — sync-claude could delete your CLAUDE.md prose

`applyPlan` matched both markers with a bare first-`indexOf`, no ordering or balance check, against a file the user edits by hand:

- **orphan START** (no END) failed the `includes` guard, so a *second* block was appended — and the next sync sliced from the orphan START to the new block's END, deleting everything written between them. That's the data-loss path, and it takes two syncs to spring.
- **END before START** produced `slice(0, start) + block + slice(end)` with `end < start`, duplicating the region.
- a **second complete block** was left behind forever.
- markers **inside a fenced code block** counted as real, so a CLAUDE.md documenting vir's own markers got edited at the example.

Markers are now found fence-aware and paired forward into complete blocks. Unbalanced markers are refused with a reason and nothing is written — appending is what armed the deletion, and a hand-edit gone wrong is the user's to fix. Duplicates collapse to one.

`applyPlan` returns `{ ok, reason }` instead of a bare boolean. Worth noting: the old call site did `const ok = applyPlan(p)`, and since an object is always truthy, a refusal would have rendered as a green tick. `tsc` was perfectly happy with that — it only surfaced from reading the call site.

## #14 — a pricing override for an unknown model logged $0

`resolvePricing` returned null the moment the model was absent from `DEFAULT_PRICING`, *before* consulting overrides — so `config.pricing` for a model id newer than the table, which is precisely what the override exists for, priced the run at $0 silently. Only a **complete** override stands alone: with no base to patch, half a price is a wrong price, not a partial one.

## #19 — MCP told clients three untrue things

- announced `version: "0.1.1"`, a literal untouched since the first release. Now `readVirVersion()`, with a test asserting the initialiser carries no literal at all.
- `vir mcp install` advertised 4 tools; the server registers 6 (`vir_recent_articles`, `vir_compose` missing). Both sides read one `VIR_TOOLS` list, pinned by a test that scans the server's own `registerTool` calls — a new tool can't ship half-announced.
- `getStats()` names six migration-added columns and the read-only MCP path deliberately skips migrations, so on an upgraded-but-never-written DB `vir_status` died with `no such column: category`. It now degrades to empty stats, which is what the aggregation produces from zero rows anyway.

## Tests

17 new, each written first and watched fail for its own reason — including the two SQLite and slice-level failures the findings predicted verbatim. 557 pass, 51 files, `tsc --noEmit` clean.

## Scope note

`src/version.ts` is new, and `cli.ts` and `doctor.ts` keep their own inline package.json reads. I did not convert them — that's beyond the finding — but three hand-counted `..` hops to the same file is the drift this class of bug comes from, and it's a small follow-up.

As before, `site/node_modules` is empty in my worktree so the site suite is CI-verified only; the only site change is the test count.