### PR TITLE
feat: vir prune — demote agent-derived notes, never delete them

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import {
   type Config,
 } from "./config.js";
 import { applyPlan, planUpdates, type PlanItem } from "./claude/updater.js";
+import { pruneCommand } from "./cli/pruneAction.js";
 import { detectDuplicates } from "./dedupe/detector.js";
 import { mergeNotes } from "./dedupe/merger.js";
 import {
@@ -1669,6 +1670,17 @@ program
   .option("--project <slug>", "Filter by project")
   .option("--limit <n>", "Max notes to review in this session", "50")
   .action(runAction(runReview));
+
+program
+  .command("prune")
+  .description("Demote agent-derived notes to .rejected/ (dry run by default)")
+  .option("--apply", "Actually demote (default is a dry run)")
+  .option("--restore", "Restore every pruned note to its exact prior state")
+  .action(
+    runAction(async (opts: { apply?: boolean; restore?: boolean }) => {
+      await pruneCommand(opts);
+    }),
+  );
 
 program
   .command("doctor")

--- a/src/cli/pruneAction.ts
+++ b/src/cli/pruneAction.ts
@@ -1,0 +1,111 @@
+import { loadConfig } from "../config.js";
+import {
+  applyPrunePlan,
+  buildPrunePlan,
+  restorePruned,
+  type PrunePlan,
+} from "../prune/prune.js";
+import { StateDb } from "../state/db.js";
+import * as ui from "../ui/display.js";
+
+export interface PruneCliOptions {
+  apply?: boolean;
+  restore?: boolean;
+  dryRun?: boolean;
+}
+
+function renderPlan(plan: PrunePlan): void {
+  ui.header("prune — agent-derived notes");
+  ui.blank();
+
+  const reasons = Object.entries(plan.byReason).sort((a, b) => b[1] - a[1]);
+  if (reasons.length === 0) {
+    ui.row(ui.success(ui.CHECK), ui.text("nothing to prune"));
+  } else {
+    for (const [reason, n] of reasons) {
+      ui.row(ui.warn(ui.DIAMOND), ui.text(reason), ui.dim(String(n)));
+    }
+  }
+
+  ui.blank();
+  ui.line(ui.dim("  kept:"));
+  for (const [reason, n] of Object.entries(plan.byKeepReason).sort(
+    (a, b) => b[1] - a[1],
+  )) {
+    // The two report-only buckets are the honest part of this command: no
+    // evidence exists to judge them, so they are never touched.
+    const note =
+      reason === "unclassifiable"
+        ? " (no entrypoint, transcript gone — never pruned)"
+        : reason === "merge-winner"
+          ? " (merge parentage unknown — never pruned)"
+          : "";
+    ui.line(ui.dim(`    ${reason}: ${n}${note}`));
+  }
+
+  ui.blank();
+  ui.divider();
+  ui.summary({
+    "would prune": { value: plan.prune.length, color: ui.warn },
+    keep: { value: plan.keep.length, color: ui.info },
+    "already pruned": { value: plan.alreadyPruned, color: ui.dim },
+    "dangling links": {
+      value: plan.danglingLinks,
+      color: plan.danglingLinks > 0 ? ui.warn : ui.dim,
+    },
+  });
+  ui.divider();
+  if (plan.danglingLinks > 0) {
+    ui.line(
+      ui.dim(
+        `  ${plan.danglingLinks} wikilink(s) in kept notes point at a pruned note — reported, not rewritten`,
+      ),
+    );
+  }
+}
+
+export async function pruneCommand(opts: PruneCliOptions): Promise<void> {
+  const cfg = await loadConfig();
+  const db = new StateDb();
+  try {
+    if (opts.restore === true) {
+      const res = restorePruned(db, cfg);
+      ui.header("prune --restore");
+      ui.blank();
+      ui.summary({
+        restored: { value: res.restored, color: ui.success },
+        "file missing": {
+          value: res.missing,
+          color: res.missing > 0 ? ui.warn : ui.dim,
+        },
+      });
+      return;
+    }
+
+    const plan = buildPrunePlan(db, cfg);
+    renderPlan(plan);
+
+    // Dry run is the default: this command demotes a chunk of the vault, so
+    // the destructive-looking path has to be the one you ask for by name.
+    if (opts.apply !== true) {
+      ui.blank();
+      ui.line(ui.dim("  dry run — nothing moved, nothing written"));
+      ui.line(ui.dim("  run `vir prune --apply` to demote, `--restore` to undo"));
+      return;
+    }
+
+    const res = applyPrunePlan(db, cfg, plan);
+    ui.blank();
+    ui.summary({
+      "notes moved": { value: res.moved, color: ui.success },
+      "rows marked": { value: res.marked, color: ui.success },
+      "state only": {
+        value: res.stateOnly,
+        color: res.stateOnly > 0 ? ui.warn : ui.dim,
+      },
+    });
+    ui.line(ui.dim("  demoted to .rejected/ — `vir prune --restore` puts them back"));
+  } finally {
+    db.close();
+  }
+}

--- a/src/diagnostics/doctor.test.ts
+++ b/src/diagnostics/doctor.test.ts
@@ -8,6 +8,7 @@ import {
   ollamaCheck,
   pendingProjectsCheck,
   queryLogCheck,
+  prunedNotesCheck,
 } from "./doctor.js";
 
 // The doctor Ollama check must be probe-based, not reachability-based: a
@@ -309,5 +310,26 @@ describe("embeddingProviderCheck", () => {
     expect(r.detail).toMatch(/14/);
     expect(r.detail).toMatch(/different model/);
     expect(r.detail).toMatch(/vir embed --force/);
+  });
+});
+
+// Pruned notes are demoted, not deleted — so the only place the user can see
+// how much of their vault is sitting in `.rejected/`, and why, is doctor.
+// Human table only: `doctor --json` is a cross-repo 8-field contract.
+describe("prunedNotesCheck", () => {
+  it("reports nothing when no notes are pruned", () => {
+    expect(prunedNotesCheck({})).toBeNull();
+  });
+
+  it("reports the total and a per-reason breakdown", () => {
+    const r = prunedNotesCheck({
+      "sidechain-transcript": 132,
+      "workflow-transcript": 3,
+    });
+    expect(r?.label).toBe("pruned notes");
+    expect(r?.detail).toContain("135");
+    expect(r?.detail).toContain("sidechain-transcript 132");
+    expect(r?.detail).toContain("workflow-transcript 3");
+    expect(r?.detail).toContain("vir prune --restore");
   });
 });

--- a/src/diagnostics/doctor.ts
+++ b/src/diagnostics/doctor.ts
@@ -523,6 +523,44 @@ function checkBackup(): CheckResult | null {
   );
 }
 
+// ── 7c. pruned notes ──────────────────────────────────────────────────────────
+// `vir prune` demotes notes into `.rejected/` rather than deleting them, so
+// without a report the vault quietly shrinks with nothing saying why or how to
+// undo it. Null when nothing is pruned — doctor should not grow a row for a
+// feature the user has not used. Human table ONLY, never doctor --json (the
+// 8-field VirDoctorResult is a cross-repo contract).
+function checkPrunedNotes(): CheckResult | null {
+  let db: StateDb | null = null;
+  try {
+    db = new StateDb(STATE_PATH, { readonly: true });
+    return prunedNotesCheck(db.countPrunedByReason());
+  } catch {
+    // No DB yet, or an ancient one without the column. The database row above
+    // already reports a missing DB; this check stays silent rather than
+    // doubling the noise.
+    return null;
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export function prunedNotesCheck(
+  byReason: Record<string, number>,
+): CheckResult | null {
+  const entries = Object.entries(byReason).sort((a, b) => b[1] - a[1]);
+  if (entries.length === 0) return null;
+  const total = entries.reduce((n, [, v]) => n + v, 0);
+  const breakdown = entries.map(([r, n]) => `${r} ${n}`).join(", ");
+  return ok(
+    "pruned notes",
+    `${total} demoted to .rejected/ (${breakdown}) — vir prune --restore to undo`,
+  );
+}
+
 // ── 7b. query log ─────────────────────────────────────────────────────────────
 // appendQueryLog is best-effort (a log failure must never fail a query), so
 // the queries.failed marker is its only durable failure signal. Surface
@@ -748,6 +786,8 @@ export async function runDoctor(): Promise<void> {
   const backup = checkBackup();
   if (backup) record(backup);
   record(checkQueryLog(cfg));
+  const pruned = checkPrunedNotes();
+  if (pruned) record(pruned);
   const limitPattern = checkClaudeCliLimitPattern(cfg);
   if (limitPattern) record(limitPattern);
 

--- a/src/pipeline/run.claudeCli.test.ts
+++ b/src/pipeline/run.claudeCli.test.ts
@@ -19,6 +19,7 @@ vi.mock("../state/db.js", () => ({
   StateDb: class {
     isProcessed = vi.fn(() => false);
     retryExhausted = vi.fn(() => false);
+    isPruned = vi.fn(() => false);
     record = vi.fn();
     recordError = spies.recordError;
     getByPath = vi.fn(() => undefined);

--- a/src/pipeline/run.preflightProbe.test.ts
+++ b/src/pipeline/run.preflightProbe.test.ts
@@ -16,6 +16,7 @@ vi.mock("../state/db.js", () => ({
   StateDb: class {
     isProcessed = vi.fn(() => false);
     retryExhausted = vi.fn(() => false);
+    isPruned = vi.fn(() => false);
     record = vi.fn();
     recordError = vi.fn();
     listDistilled = vi.fn(() => []);

--- a/src/pipeline/run.projectFilter.test.ts
+++ b/src/pipeline/run.projectFilter.test.ts
@@ -21,6 +21,7 @@ vi.mock("../state/db.js", () => ({
   StateDb: class {
     isProcessed = vi.fn(() => false);
     retryExhausted = vi.fn(() => false);
+    isPruned = vi.fn(() => false);
     record = spies.record;
     recordError = vi.fn();
     getByPath = spies.getByPath;

--- a/src/pipeline/run.prunedSkip.test.ts
+++ b/src/pipeline/run.prunedSkip.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "../config.js";
+import { runPipeline } from "./run.js";
+
+// A pruned session must not reach the paid boundary under --full. Without the
+// gate, `--full` re-distills every pruned session (a paid classify + distill
+// each) and only discovers at write() that the note is demoted — so the bill
+// arrives every time, forever, for notes the user deliberately removed.
+
+const spies = vi.hoisted(() => ({
+  distill: vi.fn(async () => null),
+  record: vi.fn(),
+  probe: vi.fn(async () => {}),
+  notify: vi.fn(),
+  getByPath: vi.fn((..._args: unknown[]): unknown => undefined),
+  isPruned: vi.fn((..._args: unknown[]): boolean => false),
+}));
+
+vi.mock("../state/db.js", () => ({
+  StateDb: class {
+    isProcessed = vi.fn(() => false);
+    retryExhausted = vi.fn(() => false);
+    isPruned = spies.isPruned;
+    record = spies.record;
+    recordError = vi.fn();
+    getByPath = spies.getByPath;
+    listDistilled = vi.fn(() => []);
+    listEmbeddingTargets = vi.fn(() => []);
+    listTopicEmbeddingTargets = vi.fn(() => []);
+    listArticleEmbeddingTargets = vi.fn(() => []);
+    listPdfEmbeddingTargets = vi.fn(() => []);
+    close = vi.fn();
+  },
+}));
+
+vi.mock("./writer.js", () => ({
+  kebab: (s: string) => s,
+  VaultWriter: class {
+    write = vi.fn(async (): Promise<string[]> => []);
+    regenerateIndex = vi.fn();
+  },
+}));
+
+vi.mock("./scanner.js", () => ({
+  scanSessions: () => [
+    { path: "/t/projects/demo/s1.jsonl", hash: "h1", size: 1000 },
+    { path: "/t/projects/scratch/s2.jsonl", hash: "h2", size: 2000 },
+  ],
+}));
+
+vi.mock("./parser.js", () => ({
+  parseSession: (path: string, hash: string) => ({
+    path,
+    hash,
+    sessionId: path.split("/").pop()?.replace(".jsonl", "") ?? "s",
+    projectSlug: "demo",
+    startedAt: null,
+    endedAt: null,
+    lineCount: 10,
+    toolCallCount: 0,
+    filesTouched: [],
+    assistantText: "a",
+    userText: "u",
+    rawSummary: "s",
+    transcriptText: "t",
+  }),
+}));
+
+vi.mock("./filter.js", () => ({
+  scoreSession: () => ({ passes: true, score: 10 }),
+}));
+
+vi.mock("./distiller.js", async (importOriginal) => {
+  const real = await importOriginal<typeof import("./distiller.js")>();
+  return {
+    ...real,
+    probeProvider: spies.probe,
+    Distiller: class {
+      run = spies.distill;
+    },
+  };
+});
+
+vi.mock("./embeddingSweep.js", () => ({
+  sweepEmbeddings: async () => ({
+    ran: false,
+    embedded: 0,
+    errors: 0,
+    pending: 0,
+  }),
+}));
+
+function cfg(projects: Record<string, "include" | "exclude">): Config {
+  return {
+    vaultPath: "/tmp/vir-test-vault",
+    outputDir: "Vir",
+    claudeProjectsDir: "/t/projects",
+    provider: "kie",
+    filterThreshold: 1,
+    projects,
+    notifications: false,
+    models: { classify: "claude-haiku-4-5", distill: "claude-sonnet-4-6" },
+  } as unknown as Config;
+}
+
+
+describe("runPipeline — pruned sessions under --full", () => {
+  beforeEach(() => {
+    spies.distill.mockClear();
+    spies.record.mockClear();
+    spies.probe.mockClear();
+    spies.getByPath.mockReset();
+    spies.getByPath.mockReturnValue(undefined);
+    spies.isPruned.mockReset();
+    spies.isPruned.mockReturnValue(false);
+  });
+
+  it("--full never re-distills a pruned session", async () => {
+    spies.isPruned.mockReturnValue(true);
+
+    await runPipeline(cfg({ demo: "include", scratch: "include" }), {
+      quiet: true,
+      full: true,
+    });
+
+    expect(spies.distill).not.toHaveBeenCalled();
+  });
+
+  it("--full still distills a session that is not pruned", async () => {
+    await runPipeline(cfg({ demo: "include", scratch: "include" }), {
+      quiet: true,
+      full: true,
+    });
+
+    expect(spies.distill).toHaveBeenCalled();
+  });
+});

--- a/src/pipeline/run.retryBound.test.ts
+++ b/src/pipeline/run.retryBound.test.ts
@@ -16,6 +16,7 @@ vi.mock("../state/db.js", () => ({
   StateDb: class {
     isProcessed = vi.fn(() => false);
     retryExhausted = spies.exhausted;
+    isPruned = vi.fn(() => false);
     record = vi.fn();
     recordError = spies.recordError;
     listDistilled = vi.fn(() => []);

--- a/src/pipeline/run.transcriptFilter.test.ts
+++ b/src/pipeline/run.transcriptFilter.test.ts
@@ -20,6 +20,7 @@ vi.mock("../state/db.js", () => ({
   StateDb: class {
     isProcessed = vi.fn(() => false);
     retryExhausted = vi.fn(() => false);
+    isPruned = vi.fn(() => false);
     record = spies.record;
     recordError = vi.fn();
     getByPath = spies.getByPath;

--- a/src/pipeline/run.ts
+++ b/src/pipeline/run.ts
@@ -852,6 +852,16 @@ export async function runPipeline(
         continue;
       }
 
+      // A pruned session is demoted on purpose — even under --full. The gate
+      // belongs HERE, at the paid boundary, not at write(): the writer would
+      // catch it, but only after a classify and a distill have been billed,
+      // every run, forever. `vir prune --restore` is the way back in.
+      if (db.isPruned(found.path)) {
+        summary.alreadyProcessed += 1;
+        fileLog(`pruned, skipping: ${found.path}`);
+        continue;
+      }
+
       // Retry bound: MAX_DISTILL_ATTEMPTS consecutive failures park the
       // session — even under --full — so the daemon can't burn money on a
       // persistently failing transcript. `vir reconcile --force` is the only

--- a/src/pipeline/writer.ts
+++ b/src/pipeline/writer.ts
@@ -45,7 +45,7 @@ import { kebab, makeSlug, sessionSuffix } from "./slug.js";
 // cli/review.ts so the two sides can't drift apart.
 export const REJECTED_DIR = ".rejected";
 
-const CATEGORY_DIR: Record<Category, string> = {
+export const CATEGORY_DIR: Record<Category, string> = {
   pattern: "patterns",
   gotcha: "gotchas",
   decision: "decisions",

--- a/src/prune/classify.test.ts
+++ b/src/prune/classify.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { classifyRow, type PruneRow } from "./classify.js";
+
+const PROJECTS = "/home/u/.claude/projects";
+const row = (over: Partial<PruneRow> = {}): PruneRow => ({
+  path: `${PROJECTS}/-home-u-projects-app/abc12345.jsonl`,
+  entrypoint: null,
+  isMergeWinner: false,
+  ...over,
+});
+
+describe("prune classification", () => {
+  it("prunes a sidechain transcript from its path alone", () => {
+    expect(
+      classifyRow(
+        row({ path: `${PROJECTS}/-home-u-app/subagents/xyz.jsonl` }),
+        PROJECTS,
+      ),
+    ).toEqual({ action: "prune", reason: "sidechain-transcript" });
+  });
+
+  it("prunes a workflow transcript from its path alone", () => {
+    expect(
+      classifyRow(
+        row({ path: `${PROJECTS}/-home-u-app/subagents/wf_123/x.jsonl` }),
+        PROJECTS,
+      ),
+    ).toEqual({ action: "prune", reason: "workflow-transcript" });
+  });
+
+  it("prunes a row whose stored entrypoint is an sdk launcher", () => {
+    expect(classifyRow(row({ entrypoint: "sdk-py" }), PROJECTS)).toEqual({
+      action: "prune",
+      reason: "agent-transcript",
+    });
+  });
+
+  // The C23 serbeval trap, from tasks/lessons.md: promptSource reads "sdk" on
+  // a DESKTOP-launched human session. entrypoint is the only safe separator,
+  // so the classifier must never consult anything else.
+  it("never prunes a desktop-launched human session", () => {
+    expect(classifyRow(row({ entrypoint: "claude-desktop" }), PROJECTS)).toEqual({
+      action: "keep",
+      reason: "human-entrypoint",
+    });
+  });
+
+  it("never prunes a cli human session", () => {
+    expect(classifyRow(row({ entrypoint: "cli" }), PROJECTS)).toEqual({
+      action: "keep",
+      reason: "human-entrypoint",
+    });
+  });
+
+  // Turn count would kill these — a single-prompt autonomous run is a human
+  // session with one turn. The classifier sees no turn data at all, by design.
+  it("never prunes a single-prompt autonomous human run", () => {
+    expect(
+      classifyRow(
+        row({ path: `${PROJECTS}/-home-u-app/single.jsonl`, entrypoint: "cli" }),
+        PROJECTS,
+      ),
+    ).toEqual({ action: "keep", reason: "human-entrypoint" });
+  });
+
+  it("reports an unclassifiable row instead of pruning it", () => {
+    expect(classifyRow(row(), PROJECTS)).toEqual({
+      action: "keep",
+      reason: "unclassifiable",
+    });
+  });
+
+  // Merge parentage is not recorded anywhere, so a winner's sources cannot be
+  // shown to be all-agent. Never prune what cannot be shown safe.
+  it("never prunes a merge winner, even one on an agent path", () => {
+    expect(
+      classifyRow(
+        row({
+          path: `${PROJECTS}/-home-u-app/subagents/x.jsonl`,
+          isMergeWinner: true,
+        }),
+        PROJECTS,
+      ),
+    ).toEqual({ action: "keep", reason: "merge-winner" });
+  });
+});

--- a/src/prune/classify.ts
+++ b/src/prune/classify.ts
@@ -1,0 +1,54 @@
+import { classifyTranscript } from "../pipeline/projects.js";
+
+// Why a row is being demoted. These mirror the forward-only skip reasons
+// 0.14.0 introduced, so the vault tells one story about agent transcripts
+// whether they were filtered at scan time or pruned afterwards.
+export type PruneReason =
+  | "workflow-transcript"
+  | "sidechain-transcript"
+  | "agent-transcript";
+
+// Why a row survives. `unclassifiable` and `merge-winner` are reported, never
+// acted on — they are the two buckets where the evidence does not exist.
+export type KeepReason = "human-entrypoint" | "unclassifiable" | "merge-winner";
+
+export type PruneDecision =
+  | { action: "prune"; reason: PruneReason }
+  | { action: "keep"; reason: KeepReason };
+
+export interface PruneRow {
+  path: string;
+  entrypoint: string | null;
+  // The note carries an "## Archived Duplicates" section, i.e. `vir dedupe`
+  // merged at least one other note into it.
+  isMergeWinner: boolean;
+}
+
+// Decide one row. Pure and zero-I/O: 396 of 411 distilled transcripts are
+// already deleted from disk (Claude Code prunes at ~30 days), so any rule that
+// needs to READ the transcript can decide almost nothing. Everything here comes
+// from the stored path and the stored entrypoint.
+export function classifyRow(row: PruneRow, projectsDir: string): PruneDecision {
+  // A merge winner's sources are not recorded anywhere, so it can never be
+  // SHOWN to be all-agent. Checked first: it outranks every prune signal.
+  if (row.isMergeWinner) return { action: "keep", reason: "merge-winner" };
+
+  // entrypoint is the only trustworthy launcher signal (lessons.md: promptSource
+  // reads "sdk" on desktop-launched human sessions, and turn count kills
+  // single-prompt autonomous runs). A known non-sdk launcher is a human.
+  if (row.entrypoint !== null) {
+    return row.entrypoint.startsWith("sdk")
+      ? { action: "prune", reason: "agent-transcript" }
+      : { action: "keep", reason: "human-entrypoint" };
+  }
+
+  const structural = classifyTranscript(row.path, projectsDir);
+  if (structural === "workflow")
+    return { action: "prune", reason: "workflow-transcript" };
+  if (structural === "sidechain")
+    return { action: "prune", reason: "sidechain-transcript" };
+
+  // Null entrypoint, ordinary path, transcript long gone: no evidence either
+  // way. 241 of 411 live rows land here. Reported, never pruned.
+  return { action: "keep", reason: "unclassifiable" };
+}

--- a/src/prune/prune.test.ts
+++ b/src/prune/prune.test.ts
@@ -1,0 +1,225 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Config } from "../config.js";
+import { LockHeldError } from "../pipeline/lock.js";
+import { StateDb } from "../state/db.js";
+import { applyPrunePlan, buildPrunePlan, restorePruned } from "./prune.js";
+
+const PROV = { model: "nomic-embed-text", dim: 3 };
+
+let root: string;
+let vault: string;
+let projects: string;
+let db: StateDb;
+let lockPath: string;
+
+function cfg(): Config {
+  return {
+    vaultPath: vault,
+    outputDir: "vir",
+    topicsDir: "topics",
+    claudeProjectsDir: projects,
+    cadenceHours: 3,
+    provider: "anthropic",
+    anthropicApiKey: "sk-ant-test",
+    kieTopUpTier: "standard",
+    filterThreshold: 0.4,
+    distillArticles: true,
+    distillPdfs: true,
+    filterToolCalls: "moderate",
+    retrievalDiversity: 0.3,
+    models: { classify: "claude-haiku-4-5-20251001", distill: "claude-sonnet-4-6" },
+  } as Config;
+}
+
+// One distilled row + its note file on disk.
+function seed(opts: {
+  sessionId: string;
+  sub?: string;
+  entrypoint?: string | null;
+  topic: string;
+  body?: string;
+}): string {
+  const dir = opts.sub
+    ? join(projects, "-h-app", opts.sub)
+    : join(projects, "-h-app");
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `${opts.sessionId}.jsonl`);
+  db.record({
+    path,
+    hash: `h-${opts.sessionId}`,
+    skipped: false,
+    notePaths: [],
+    content: opts.body ?? `body of ${opts.topic}`,
+    category: "pattern",
+    topic: opts.topic,
+    project: "demo",
+    confidence: 0.9,
+    startedAt: "2026-05-01T00:00:00.000Z",
+    entrypoint: opts.entrypoint ?? null,
+  });
+  db.storeEmbedding(opts.sessionId, [1, 0, 0], PROV);
+  const slug = `${opts.topic.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${opts.sessionId.slice(0, 8)}`;
+  const note = join(vault, "vir", "patterns", `${slug}.md`);
+  mkdirSync(join(vault, "vir", "patterns"), { recursive: true });
+  writeFileSync(
+    note,
+    `---\ntopic: "${opts.topic}"\ncategory: pattern\nsession_id: ${opts.sessionId}\n---\n\n${opts.body ?? "body"}\n`,
+  );
+  return note;
+}
+
+describe("vir prune", () => {
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "vir-prune-"));
+    vault = join(root, "vault");
+    projects = join(root, "projects");
+    lockPath = join(root, "vir.lock");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(projects, { recursive: true });
+    db = new StateDb(join(root, "vir.db"));
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("dry-run writes nothing: no DB change, no file moved", () => {
+    const note = seed({ sessionId: "aaaa1111", sub: "subagents", topic: "agent thing" });
+    const before = readFileSync(note, "utf8");
+
+    const plan = buildPrunePlan(db, cfg());
+
+    expect(plan.prune).toHaveLength(1);
+    expect(existsSync(note)).toBe(true);
+    expect(readFileSync(note, "utf8")).toBe(before);
+    expect(db.getByPath(plan.prune[0]!.path)?.pruned_at ?? null).toBeNull();
+    expect(db.listDistilled()).toHaveLength(1);
+  });
+
+  it("reports counts per reason and the unclassifiable bucket", () => {
+    seed({ sessionId: "aaaa1111", sub: "subagents", topic: "side one" });
+    seed({ sessionId: "bbbb2222", sub: join("subagents", "wf_9"), topic: "wf one" });
+    seed({ sessionId: "cccc3333", entrypoint: "sdk-py", topic: "sdk one" });
+    seed({ sessionId: "dddd4444", topic: "mystery" });
+    seed({ sessionId: "eeee5555", entrypoint: "cli", topic: "human one" });
+
+    const plan = buildPrunePlan(db, cfg());
+
+    expect(plan.byReason).toEqual({
+      "sidechain-transcript": 1,
+      "workflow-transcript": 1,
+      "agent-transcript": 1,
+    });
+    expect(plan.byKeepReason.unclassifiable).toBe(1);
+    expect(plan.byKeepReason["human-entrypoint"]).toBe(1);
+  });
+
+  it("apply moves the note, stamps frontmatter, sets prune state, leaves skipped alone", () => {
+    const note = seed({ sessionId: "aaaa1111", sub: "subagents", topic: "agent thing" });
+    const plan = buildPrunePlan(db, cfg());
+
+    applyPrunePlan(db, cfg(), plan, { lockPath });
+
+    expect(existsSync(note)).toBe(false);
+    const moved = join(vault, "vir", ".rejected", "agent-thing-aaaa1111.md");
+    expect(existsSync(moved)).toBe(true);
+    expect(readFileSync(moved, "utf8")).toContain("pruned_at:");
+    expect(readFileSync(moved, "utf8")).toContain("prune_reason: sidechain-transcript");
+
+    const row = db.getByPath(plan.prune[0]!.path);
+    expect(row?.pruned_at).toBeTruthy();
+    expect(row?.skipped).toBe(0);
+    expect(row?.skip_reason ?? null).toBeNull();
+  });
+
+  it("a pruned note is gone from every DB-backed read path", () => {
+    seed({ sessionId: "aaaa1111", sub: "subagents", topic: "agent thing" });
+    applyPrunePlan(db, cfg(), buildPrunePlan(db, cfg()), { lockPath });
+
+    expect(db.listDistilled()).toHaveLength(0);
+    expect(db.getStats().total).toBe(0);
+    expect(db.getEmbeddings(join(vault, "vir"))).toHaveLength(0);
+    expect(db.listEmbeddingTargets()).toHaveLength(0);
+    expect(db.listReconcileTargets()).toHaveLength(0);
+  });
+
+  it("no resurrection: the session stays processed and is not a reconcile target", () => {
+    seed({ sessionId: "aaaa1111", sub: "subagents", topic: "agent thing" });
+    const plan = buildPrunePlan(db, cfg());
+    applyPrunePlan(db, cfg(), plan, { lockPath });
+
+    expect(db.isProcessed(plan.prune[0]!.path, "h-aaaa1111")).toBe(true);
+    expect(db.listReconcileTargets()).toHaveLength(0);
+  });
+
+  it("never prunes an unclassifiable row", () => {
+    seed({ sessionId: "dddd4444", topic: "mystery" });
+    const plan = buildPrunePlan(db, cfg());
+    expect(plan.prune).toHaveLength(0);
+    expect(plan.keep.map((k) => k.decision.reason)).toContain("unclassifiable");
+  });
+
+  it("never prunes a merge winner, and reports it", () => {
+    const note = seed({ sessionId: "aaaa1111", sub: "subagents", topic: "agent thing" });
+    writeFileSync(note, `${readFileSync(note, "utf8")}\n## Archived Duplicates\n- [[x]]\n`);
+
+    const plan = buildPrunePlan(db, cfg());
+
+    expect(plan.prune).toHaveLength(0);
+    expect(plan.byKeepReason["merge-winner"]).toBe(1);
+  });
+
+  it("restore is a byte-exact round trip, DB row and embedding included", () => {
+    const note = seed({ sessionId: "aaaa1111", sub: "subagents", topic: "agent thing" });
+    const bytesBefore = readFileSync(note, "utf8");
+    const rowBefore = db.getByPath(join(projects, "-h-app", "subagents", "aaaa1111.jsonl"));
+    const embBefore = db.getEmbeddings(join(vault, "vir")).length;
+
+    applyPrunePlan(db, cfg(), buildPrunePlan(db, cfg()), { lockPath });
+    const res = restorePruned(db, cfg(), { lockPath });
+
+    expect(res.restored).toBe(1);
+    expect(readFileSync(note, "utf8")).toBe(bytesBefore);
+    const rowAfter = db.getByPath(join(projects, "-h-app", "subagents", "aaaa1111.jsonl"));
+    expect(rowAfter?.content).toBe(rowBefore?.content);
+    expect(rowAfter?.hash).toBe(rowBefore?.hash);
+    expect(rowAfter?.pruned_at ?? null).toBeNull();
+    expect(db.getEmbeddings(join(vault, "vir")).length).toBe(embBefore);
+  });
+
+  it("apply and restore acquire the lock", () => {
+    seed({ sessionId: "aaaa1111", sub: "subagents", topic: "agent thing" });
+    writeFileSync(lockPath, String(process.pid));
+
+    expect(() =>
+      applyPrunePlan(db, cfg(), buildPrunePlan(db, cfg()), { lockPath }),
+    ).toThrow(LockHeldError);
+    expect(() => restorePruned(db, cfg(), { lockPath })).toThrow(LockHeldError);
+  });
+
+  it("never edits a kept note, and reports dangling links instead of fixing them", () => {
+    seed({ sessionId: "aaaa1111", sub: "subagents", topic: "agent thing" });
+    const keeper = seed({ sessionId: "eeee5555", entrypoint: "cli", topic: "human one" });
+    writeFileSync(
+      keeper,
+      `${readFileSync(keeper, "utf8")}\n## Related\n- [[agent-thing-aaaa1111]]\n`,
+    );
+    const keeperBefore = readFileSync(keeper, "utf8");
+
+    const plan = buildPrunePlan(db, cfg());
+    expect(plan.danglingLinks).toBe(1);
+
+    applyPrunePlan(db, cfg(), plan, { lockPath });
+    expect(readFileSync(keeper, "utf8")).toBe(keeperBefore);
+  });
+});

--- a/src/prune/prune.ts
+++ b/src/prune/prune.ts
@@ -1,0 +1,272 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, join } from "node:path";
+import { setFrontmatter } from "../cli/review.js";
+import type { Config } from "../config.js";
+import { acquireLock, releaseLock, LOCK_PATH } from "../pipeline/lock.js";
+import { makeSlug } from "../pipeline/slug.js";
+import { CATEGORY_DIR, REJECTED_DIR } from "../pipeline/writer.js";
+import type { PruneCandidateRow, StateDb } from "../state/db.js";
+import { classifyRow, type PruneDecision } from "./classify.js";
+
+// Frontmatter keys prune owns. Deliberately NOT review's `rejected_at`: a note
+// can be both review-rejected and pruned, and stripping a key we did not write
+// would make `--restore` lossy. `.rejected/` residency is what review's own
+// mechanics key on (collectNotes skips the directory), not the key.
+const PRUNED_AT = "pruned_at";
+const PRUNE_REASON = "prune_reason";
+
+export interface PrunePlanItem {
+  path: string;
+  sessionId: string;
+  slug: string;
+  notePath: string;
+  noteExists: boolean;
+  topic: string;
+  project: string | null;
+  decision: PruneDecision;
+}
+
+export interface PrunePlan {
+  prune: PrunePlanItem[];
+  keep: PrunePlanItem[];
+  alreadyPruned: number;
+  byReason: Record<string, number>;
+  byKeepReason: Record<string, number>;
+  // Links in notes we are KEEPING that point at a note we would demote.
+  // Reported, never repaired: rewriting a kept note is an edit the user did
+  // not ask for, and the count is the honest cost of the operation.
+  danglingLinks: number;
+}
+
+export interface PruneIoOptions {
+  lockPath?: string;
+  now?: string;
+}
+
+function vaultRoot(cfg: Config): string {
+  return join(cfg.vaultPath, cfg.outputDir);
+}
+
+function deriveSessionId(path: string): string {
+  return basename(path).replace(/\.jsonl$/, "");
+}
+
+function noteIsMergeWinner(notePath: string): boolean {
+  try {
+    return readFileSync(notePath, "utf8").includes("## Archived Duplicates");
+  } catch {
+    return false;
+  }
+}
+
+function toItem(row: PruneCandidateRow, cfg: Config): PrunePlanItem {
+  const sessionId = deriveSessionId(row.path);
+  const slug = makeSlug(row.topic, sessionId);
+  const notePath = join(
+    vaultRoot(cfg),
+    CATEGORY_DIR[row.category] ?? `${row.category}s`,
+    `${slug}.md`,
+  );
+  const noteExists = existsSync(notePath);
+  return {
+    path: row.path,
+    sessionId,
+    slug,
+    notePath,
+    noteExists,
+    topic: row.topic,
+    project: row.project,
+    decision: classifyRow(
+      {
+        path: row.path,
+        entrypoint: row.entrypoint,
+        isMergeWinner: noteExists && noteIsMergeWinner(notePath),
+      },
+      cfg.claudeProjectsDir,
+    ),
+  };
+}
+
+// Count wikilinks pointing at a to-be-pruned slug from notes that are staying.
+// Walks the live category dirs only — `.rejected/` and `archived/` are already
+// out of every read path, so a link from there costs nothing.
+function countDanglingLinks(cfg: Config, doomed: PrunePlanItem[]): number {
+  if (doomed.length === 0) return 0;
+  const slugs = new Set(doomed.map((d) => d.slug));
+  const doomedFiles = new Set(doomed.map((d) => d.notePath));
+  let count = 0;
+  for (const sub of Object.values(CATEGORY_DIR)) {
+    const dir = join(vaultRoot(cfg), sub);
+    if (!existsSync(dir)) continue;
+    for (const name of readdirSync(dir)) {
+      if (!name.endsWith(".md")) continue;
+      const full = join(dir, name);
+      if (doomedFiles.has(full)) continue;
+      let raw: string;
+      try {
+        raw = readFileSync(full, "utf8");
+      } catch {
+        continue;
+      }
+      for (const m of raw.matchAll(/\[\[([^\]|]+)/g)) {
+        if (slugs.has((m[1] ?? "").trim())) count += 1;
+      }
+    }
+  }
+  return count;
+}
+
+export function buildPrunePlan(db: StateDb, cfg: Config): PrunePlan {
+  const prune: PrunePlanItem[] = [];
+  const keep: PrunePlanItem[] = [];
+  let alreadyPruned = 0;
+  const byReason: Record<string, number> = {};
+  const byKeepReason: Record<string, number> = {};
+
+  for (const row of db.listPruneCandidates()) {
+    if (row.pruned_at !== null) {
+      alreadyPruned += 1;
+      continue;
+    }
+    const item = toItem(row, cfg);
+    if (item.decision.action === "prune") {
+      prune.push(item);
+      byReason[item.decision.reason] = (byReason[item.decision.reason] ?? 0) + 1;
+    } else {
+      keep.push(item);
+      byKeepReason[item.decision.reason] =
+        (byKeepReason[item.decision.reason] ?? 0) + 1;
+    }
+  }
+
+  return {
+    prune,
+    keep,
+    alreadyPruned,
+    byReason,
+    byKeepReason,
+    danglingLinks: countDanglingLinks(cfg, prune),
+  };
+}
+
+export interface PruneApplyResult {
+  moved: number;
+  marked: number;
+  // Rows whose note file was already absent from the category dir (a
+  // review-rejected note, or one deleted by hand). The DB state is still set —
+  // that is the half that actually gates retrieval.
+  stateOnly: number;
+}
+
+export function applyPrunePlan(
+  db: StateDb,
+  cfg: Config,
+  plan: PrunePlan,
+  opts: PruneIoOptions = {},
+): PruneApplyResult {
+  const lockPath = opts.lockPath ?? LOCK_PATH;
+  const now = opts.now ?? new Date().toISOString();
+  acquireLock(lockPath);
+  try {
+    const rejectedDir = join(vaultRoot(cfg), REJECTED_DIR);
+    let moved = 0;
+    let stateOnly = 0;
+
+    for (const item of plan.prune) {
+      if (item.decision.action !== "prune") continue;
+      if (item.noteExists) {
+        if (!existsSync(rejectedDir)) mkdirSync(rejectedDir, { recursive: true });
+        const dest = join(rejectedDir, basename(item.notePath));
+        const stamped = setFrontmatter(readFileSync(item.notePath, "utf8"), {
+          [PRUNED_AT]: now,
+          [PRUNE_REASON]: item.decision.reason,
+        });
+        writeFileSync(dest, stamped);
+        rmSync(item.notePath, { force: true });
+        moved += 1;
+      } else {
+        stateOnly += 1;
+      }
+      db.markPruned(item.path, item.decision.reason, now);
+    }
+
+    return { moved, marked: plan.prune.length, stateOnly };
+  } finally {
+    releaseLock(lockPath);
+  }
+}
+
+export interface PruneRestoreResult {
+  restored: number;
+  missing: number;
+}
+
+export function restorePruned(
+  db: StateDb,
+  cfg: Config,
+  opts: PruneIoOptions = {},
+): PruneRestoreResult {
+  const lockPath = opts.lockPath ?? LOCK_PATH;
+  acquireLock(lockPath);
+  try {
+    const rejectedDir = join(vaultRoot(cfg), REJECTED_DIR);
+    let restored = 0;
+    let missing = 0;
+
+    for (const row of db.listPruneCandidates()) {
+      if (row.pruned_at === null) continue;
+      const item = toItem(row, cfg);
+      const src = join(rejectedDir, `${item.slug}.md`);
+      if (existsSync(src)) {
+        const stripped = removeFrontmatterKeys(readFileSync(src, "utf8"), [
+          PRUNED_AT,
+          PRUNE_REASON,
+        ]);
+        mkdirSync(join(vaultRoot(cfg), CATEGORY_DIR[row.category]), {
+          recursive: true,
+        });
+        writeFileSync(item.notePath, stripped);
+        rmSync(src, { force: true });
+      } else {
+        missing += 1;
+      }
+      db.clearPruned(row.path);
+      restored += 1;
+    }
+    return { restored, missing };
+  } finally {
+    releaseLock(lockPath);
+  }
+}
+
+// Remove whole frontmatter lines for the given keys. Paired with
+// setFrontmatter, which appends new keys as their own lines, this is what makes
+// a restore byte-exact.
+export function removeFrontmatterKeys(
+  content: string,
+  keys: string[],
+): string {
+  const m = content.match(/^(---\n)([\s\S]*?)(\n---)/);
+  if (!m) return content;
+  const drop = new Set(keys);
+  const kept = (m[2] ?? "")
+    .split("\n")
+    .filter((line) => {
+      const idx = line.indexOf(":");
+      return idx === -1 || !drop.has(line.slice(0, idx).trim());
+    })
+    .join("\n");
+  return (
+    (m[1] ?? "---\n") +
+    kept +
+    (m[3] ?? "\n---") +
+    content.slice((m.index ?? 0) + m[0].length)
+  );
+}

--- a/src/prune/state.test.ts
+++ b/src/prune/state.test.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { StateDb } from "../state/db.js";
+
+const PROV = { model: "nomic-embed-text", dim: 3 };
+
+describe("prune state on the sessions row", () => {
+  let dir: string;
+  let db: StateDb;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vir-prune-db-"));
+    db = new StateDb(join(dir, "vir.db"));
+    db.record({
+      path: "/p/subagents/abc12345.jsonl",
+      hash: "h1",
+      skipped: false,
+      notePaths: ["/v/patterns/x-abc12345.md"],
+      content: "note body",
+      category: "pattern",
+      topic: "x",
+      project: "demo",
+      confidence: 0.9,
+      startedAt: "2026-05-01T00:00:00.000Z",
+    });
+    db.storeEmbedding("abc12345", [1, 0, 0], PROV);
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("is absent before pruning (the row is a normal distilled row)", () => {
+    expect(db.listDistilled()).toHaveLength(1);
+    expect(db.getStats().total).toBe(1);
+    expect(db.getEmbeddings("/v")).toHaveLength(1);
+  });
+
+  it("markPruned hides the row from every DB-backed read path", () => {
+    db.markPruned("/p/subagents/abc12345.jsonl", "sidechain-transcript");
+
+    expect(db.listDistilled()).toHaveLength(0);
+    expect(db.getStats().total).toBe(0);
+    expect(db.getEmbeddings("/v")).toHaveLength(0);
+    expect(db.listReconcileTargets()).toHaveLength(0);
+  });
+
+  // The 0.14.0 semi-prune flipped skipped=1 on already-distilled rows and
+  // called it a filter. Pruning gets its own state; `skipped` is not it.
+  it("never touches skipped, and the session stays processed", () => {
+    db.markPruned("/p/subagents/abc12345.jsonl", "sidechain-transcript");
+
+    const row = db.getByPath("/p/subagents/abc12345.jsonl");
+    expect(row?.skipped).toBe(0);
+    expect(row?.skip_reason ?? null).toBeNull();
+    // Still processed: a plain run must not re-distill (and re-bill) it.
+    expect(db.isProcessed("/p/subagents/abc12345.jsonl", "h1")).toBe(true);
+  });
+
+  it("preserves content and the embedding so a restore is exact", () => {
+    db.markPruned("/p/subagents/abc12345.jsonl", "sidechain-transcript");
+
+    const row = db.getByPath("/p/subagents/abc12345.jsonl");
+    expect(row?.content).toBe("note body");
+    expect(row?.embedding).not.toBeNull();
+    // And the sweep must not treat it as needing an embedding.
+    expect(db.listEmbeddingTargets()).toHaveLength(0);
+  });
+
+  it("clearPruned restores the row to every read path", () => {
+    db.markPruned("/p/subagents/abc12345.jsonl", "sidechain-transcript");
+    db.clearPruned("/p/subagents/abc12345.jsonl");
+
+    expect(db.listDistilled()).toHaveLength(1);
+    expect(db.getStats().total).toBe(1);
+    expect(db.getEmbeddings("/v")).toHaveLength(1);
+    const row = db.getByPath("/p/subagents/abc12345.jsonl");
+    expect(row?.pruned_at ?? null).toBeNull();
+    expect(row?.prune_reason ?? null).toBeNull();
+  });
+
+  it("counts pruned rows by reason for doctor", () => {
+    db.markPruned("/p/subagents/abc12345.jsonl", "sidechain-transcript");
+    expect(db.countPrunedByReason()).toEqual({ "sidechain-transcript": 1 });
+  });
+});

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -228,6 +228,18 @@ const ADDED_COLUMNS: Array<{ name: string; ddl: string }> = [
     ddl: "ALTER TABLE sessions ADD COLUMN skip_reason TEXT",
   },
   {
+    // Prune state. Deliberately NOT a skip_reason: `skipped` means "never
+    // distilled", and 0.14.0 learned the hard way that overloading it on a row
+    // that holds a note is a semi-prune wearing a filter's clothes. A pruned
+    // row keeps its content and embedding so a restore is exact.
+    name: "pruned_at",
+    ddl: "ALTER TABLE sessions ADD COLUMN pruned_at TEXT",
+  },
+  {
+    name: "prune_reason",
+    ddl: "ALTER TABLE sessions ADD COLUMN prune_reason TEXT",
+  },
+  {
     // Launch signature of the transcript's first user line (e.g. "sdk-py").
     // Recorded whenever the pipeline knows it; NULL for pre-existing rows.
     name: "entrypoint",
@@ -240,6 +252,18 @@ const ADDED_COLUMNS: Array<{ name: string; ddl: string }> = [
 // daemon spend on a transcript that fails persistently (each retry is a paid
 // classify call at minimum).
 export const MAX_DISTILL_ATTEMPTS = 3;
+
+// One distilled row as the prune planner sees it.
+export interface PruneCandidateRow {
+  path: string;
+  entrypoint: string | null;
+  category: Category;
+  topic: string;
+  project: string | null;
+  pruned_at: string | null;
+  prune_reason: string | null;
+  archived: number;
+}
 
 export class StateDb {
   private db: Database.Database;
@@ -389,6 +413,80 @@ export class StateDb {
     return this.columnsOf(table).has("embedding_model");
   }
 
+  // `AND pruned_at IS NULL`, or nothing when the column does not exist yet.
+  // The read-only MCP path skips migrations, so an upgraded-but-never-written
+  // DB has no prune column — naming it unconditionally would take out every
+  // read path at once, which is exactly the class of break #19 was.
+  private prunedGate(): string {
+    return this.columnsOf("sessions").has("pruned_at")
+      ? " AND pruned_at IS NULL"
+      : "";
+  }
+
+  // Demote a distilled row: it stops serving every read path but keeps its
+  // content, embedding, hash and `skipped` value, so `vir prune --restore`
+  // puts it back exactly as it was.
+  markPruned(
+    path: string,
+    reason: string,
+    now: string = new Date().toISOString(),
+  ): void {
+    this.db
+      .prepare(
+        "UPDATE sessions SET pruned_at = ?, prune_reason = ? WHERE path = ?",
+      )
+      .run(now, reason, path);
+  }
+
+  isPruned(path: string): boolean {
+    if (!this.columnsOf("sessions").has("pruned_at")) return false;
+    const row = this.db
+      .prepare("SELECT pruned_at FROM sessions WHERE path = ?")
+      .get(path) as { pruned_at: string | null } | undefined;
+    return row?.pruned_at != null;
+  }
+
+  clearPruned(path: string): void {
+    this.db
+      .prepare(
+        "UPDATE sessions SET pruned_at = NULL, prune_reason = NULL WHERE path = ?",
+      )
+      .run(path);
+  }
+
+  countPrunedByReason(): Record<string, number> {
+    if (!this.columnsOf("sessions").has("pruned_at")) return {};
+    const rows = this.db
+      .prepare(
+        `SELECT COALESCE(prune_reason, 'unknown') AS reason, COUNT(*) AS n
+         FROM sessions WHERE pruned_at IS NOT NULL GROUP BY reason`,
+      )
+      .all() as Array<{ reason: string; n: number }>;
+    const out: Record<string, number> = {};
+    for (const r of rows) out[r.reason] = r.n;
+    return out;
+  }
+
+  // Every distilled row with the fields the prune classifier needs. Already
+  // pruned rows are included so a plan can report them instead of counting
+  // them again as fresh candidates.
+  listPruneCandidates(): PruneCandidateRow[] {
+    if (!this.columnsOf("sessions").has("pruned_at")) return [];
+    return this.db
+      .prepare(
+        `SELECT path, entrypoint, category, topic, project,
+                pruned_at, prune_reason, COALESCE(archived,0) AS archived
+         FROM sessions
+         WHERE skipped = 0
+           AND error IS NULL
+           AND content IS NOT NULL
+           AND content != ''
+           AND category IS NOT NULL
+           AND topic IS NOT NULL`,
+      )
+      .all() as PruneCandidateRow[];
+  }
+
   getByPath(path: string): SessionRow | undefined {
     return this.db
       .prepare("SELECT * FROM sessions WHERE path = ?")
@@ -461,7 +559,7 @@ export class StateDb {
         `SELECT * FROM sessions
          WHERE skipped = 0
            AND (content IS NULL OR content = ''
-                OR (error IS NOT NULL AND error != ''))`,
+                OR (error IS NOT NULL AND error != ''))${this.prunedGate()}`,
       )
       .all() as SessionRow[];
   }
@@ -521,7 +619,7 @@ export class StateDb {
            AND embedding IS NULL
            AND topic IS NOT NULL
            AND category IS NOT NULL
-           AND COALESCE(archived, 0) = 0`,
+           AND COALESCE(archived, 0) = 0${this.prunedGate()}`,
       )
       .all() as EmbeddingTargetRow[];
   }
@@ -633,7 +731,7 @@ export class StateDb {
            AND content IS NOT NULL
            AND category IS NOT NULL
            AND topic IS NOT NULL
-           AND COALESCE(archived, 0) = 0`,
+           AND COALESCE(archived, 0) = 0${this.prunedGate()}`,
       )
       .all() as Array<{
       path: string;
@@ -718,7 +816,7 @@ export class StateDb {
          WHERE skipped = 0
            AND error IS NULL
            AND content IS NOT NULL
-           AND COALESCE(archived, 0) = 0`,
+           AND COALESCE(archived, 0) = 0${this.prunedGate()}`,
             )
             .all()
         : []
@@ -841,7 +939,7 @@ export class StateDb {
            AND embedding IS NOT NULL
            AND COALESCE(archived, 0) = 0
            AND topic IS NOT NULL
-           AND category IS NOT NULL`,
+           AND category IS NOT NULL${this.prunedGate()}`,
       )
       .all() as Array<{
       path: string;


### PR DESCRIPTION
Roadmap **C4** (the task was labelled C3; `vir-roadmap-v7.md:246` has C3 as "verify reviewed notes rank higher" and `:249` as "prune the existing vault"). Closes the `tasks/todo.md` prune backlog item.

0.14.0's agent-transcript filters are forward-only, so every note distilled before them is still in the vault, the embedding pool, TF-IDF and all six MCP tools. Vir's core claim is that machine-to-machine transcripts are not signal; the live vault contradicts it on every query.

**Dry run is the default. `--apply` has not been run.**

## The Phase 0 finding that shaped the design

`vir review` rejects by *moving* a note to `.rejected/`. That verdict is invisible to SQL, so it leaks through **eight DB-backed read paths**: `listDistilled` (→ summarizer, period summaries, linter, dedupe detector, `sync-claude`, `vir_recent_notes`), `getStats`/`vir status`, and the embedding sweep. Search excludes rejected notes only *incidentally* — the row stays in the candidate pool and is dropped because the moved file reads as empty content (`retriever.ts:226`). Restore the file without clearing anything and it is back in search.

A prune built on the same mechanism would inherit that bug at 132× the scale. So prune state is **`pruned_at` + `prune_reason` on the sessions row**, and every serving query carries `prunedGate()` — a no-op when the column is absent, so the read-only MCP path on an un-migrated DB does not break (the class of bug #19 was).

It is explicitly **not** `skipped`: flipping that on a row holding a note is the 0.14.0 semi-prune recorded in `tasks/lessons.md`.

## Evidence that constrained the classifier

- **`entrypoint` was never backfilled** — NULL on 376 of 411 distilled rows. The field `lessons.md` calls "the only safe separator" is unavailable for 91.5% of the history it would have to judge.
- **396 of 411 transcripts are already deleted** (Claude Code prunes at ~30 days), so any rule that reads the transcript decides almost nothing retroactively.

Classification is therefore pure and zero-I/O: the stored path yields workflow/sidechain, a stored `sdk*` entrypoint yields agent. The human traps hold by construction — the classifier reads `entrypoint` only, never `promptSource` (which reads "sdk" on desktop-launched human sessions) and never turn count (which kills single-prompt autonomous runs).

## Never touched

- **`unclassifiable`** — 231 rows with no entrypoint, no transcript, no structural signal. Reported forever.
- **`merge-winner`** — 12 rows. Dedupe records no parentage, so a winner can never be *shown* to be all-agent.
- **Kept notes.** 177 dangling wikilinks are counted and reported, not rewritten.

## Also gated at the paid boundary

`--full` bypasses `isProcessed`, so without a gate in the run loop it re-distills every pruned session — a paid classify and distill each — and only discovers at `write()` that the note is demoted. The gate sits beside the retry bound, which has the same "even under --full" reasoning.

## Restore

`--restore` is byte-exact: the row keeps its content, embedding and hash, and the note is stamped with prune's own frontmatter keys (never review's `rejected_at`), so a note that is both rejected and pruned restores cleanly. Pinned by a test asserting file bytes, DB row and embedding count all match pre-prune.

## Live dry run (against a **copy** of `~/.vir/vir.db`)

The command opens the DB read-write and migrations are writes, so to honour "no mutating command against the live DB" I ran it under a fake HOME against a byte-identical copy. The live DB's md5 is unchanged and it still has no prune columns — verified after.

```
⟡ vir  prune — agent-derived notes

⟡ sidechain-transcript  129
⟡ workflow-transcript  3

  kept:
    unclassifiable: 231 (no entrypoint, transcript gone — never pruned)
    human-entrypoint: 35
    merge-winner: 12 (merge parentage unknown — never pruned)

would prune 132  ·  keep 278  ·  already pruned 0  ·  dangling links 177

  177 wikilink(s) in kept notes point at a pruned note — reported, not rewritten
  dry run — nothing moved, nothing written
```

The `~141` estimate in todo.md was close; the `~48` in the roadmap is stale and predates the sidechain population being measured.

## Tests

**585 pass, 56 files**, `tsc --noEmit` clean. 28 new, each written first and watched fail. Five existing `run.*` harnesses needed `isPruned` added to their mocked `StateDb` — harness maintenance, not a weakened assertion.

## Filed, not fixed

Three pre-existing issues found in Phase 0 are written up in `tasks/todo.md` rather than folded in here: review's read-path leak, the un-backfilled `entrypoint`, and dedupe's missing merge parentage.

## Not done

`--apply` against the real vault. That is yours to run after verifying a backup.