### PR TITLE
fix: a rewrite with no embedder no longer wipes every Related section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ developer-tools, mcp, local-first, cross-platform, llm-wiki
   <a href="https://www.npmjs.com/package/@djolex999/vir-cli"><img src="https://img.shields.io/npm/v/@djolex999/vir-cli?color=7c6af7&label=npm" alt="npm version"></a>
   <a href="https://www.npmjs.com/package/@djolex999/vir-cli"><img src="https://img.shields.io/npm/dw/@djolex999/vir-cli?color=4fd1a0" alt="npm downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22d3ee" alt="license"></a>
-  <a href="#project-status"><img src="https://img.shields.io/badge/tests-585%20passing-22c55e" alt="tests"></a>
+  <a href="#project-status"><img src="https://img.shields.io/badge/tests-587%20passing-22c55e" alt="tests"></a>
   <a href="#project-status"><img src="https://img.shields.io/badge/platforms-macOS%20%7C%20Linux-lightgrey" alt="platforms"></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-server-c084fc" alt="mcp"></a>
   <a href="#"><img src="https://img.shields.io/badge/local--first-yes-f59e0b" alt="local-first"></a>
@@ -508,7 +508,7 @@ improvements. Delete it any time; disable it with `"logQueries": false` in
 |                |                                           |
 | -------------- | ----------------------------------------- |
 | Version        | 0.17.5                                    |
-| Tests          | 585 passing                               |
+| Tests          | 587 passing                               |
 | Platforms      | macOS (launchd), Linux (systemd/cron)     |
 | Node           | 20+                                       |
 | First-run cost | $1 to $5 (Kie.ai optional, ~72% cheaper)  |

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -23,14 +23,14 @@ export const INSTALL_CMD = `npm install -g ${NPM_PKG}`;
 //   transcriptsSeen  — rows in the sessions table
 //   transcriptsNoise — skip_reason in (workflow-transcript, agent-transcript, sidechain-transcript)
 //   transcriptsNotes — skipped=0 and note_paths != '[]'
-//   tests            — `npm test` at the repo root (585 CLI; the site's 18 are separate)
+//   tests            — `npm test` at the repo root (587 CLI; the site's 18 are separate)
 //   cost*            — `vir cost --since 180d`
 export const NUMBERS = {
   sessionsRescued: 396,
   transcriptsSeen: 1429,
   transcriptsNoise: 601,
   transcriptsNotes: 411,
-  tests: 585 as number | null,
+  tests: 587 as number | null,
   costWindow: "six months",
   costSessions: 296,
   costTotal: "$22.23" as string | null,

--- a/src/pipeline/writer.related.test.ts
+++ b/src/pipeline/writer.related.test.ts
@@ -1,0 +1,157 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Config } from "../config.js";
+import type { EmbeddingProvider } from "../search/provider.js";
+import { StateDb } from "../state/db.js";
+import type { DistilledNote, ParsedSession } from "./types.js";
+import { VaultWriter } from "./writer.js";
+
+const MODEL = "nomic-embed-text";
+
+// Returns the same vector for everything, so every note is every other note's
+// neighbour and Related is driven purely by what is in the embedding pool.
+function stubProvider(): EmbeddingProvider {
+  return {
+    name: "ollama",
+    modelName: MODEL,
+    dimensions: 3,
+    maxInputChars: 100_000,
+    available: async () => true,
+    embedDoc: async () => ({ embedding: [1, 0, 0], truncated: false, sentChars: 0 }),
+    embedQuery: async () => [1, 0, 0],
+    provenance: () => ({ model: MODEL, dim: 3 }),
+  } as unknown as EmbeddingProvider;
+}
+
+let root: string;
+let vault: string;
+let db: StateDb;
+
+function cfg(): Config {
+  return {
+    vaultPath: vault,
+    outputDir: "vir",
+    topicsDir: "topics",
+    claudeProjectsDir: "/t/projects",
+    cadenceHours: 3,
+    provider: "anthropic",
+    anthropicApiKey: "sk-ant-test",
+    kieTopUpTier: "standard",
+    filterThreshold: 0.4,
+    distillArticles: true,
+    distillPdfs: true,
+    filterToolCalls: "moderate",
+    retrievalDiversity: 0.3,
+    models: { classify: "claude-haiku-4-5-20251001", distill: "claude-sonnet-4-6" },
+  } as Config;
+}
+
+function session(id: string): ParsedSession {
+  return {
+    path: `/t/projects/demo/${id}.jsonl`,
+    hash: "",
+    sessionId: id,
+    projectSlug: "demo",
+    startedAt: "2026-05-01T10:00:00.000Z",
+    endedAt: null,
+    lineCount: 0,
+    toolCallCount: 0,
+    filesTouched: [],
+    assistantText: "",
+    userText: "",
+    rawSummary: "",
+    transcriptText: "",
+  } as unknown as ParsedSession;
+}
+
+function note(topic: string): DistilledNote {
+  return {
+    classification: {
+      category: "pattern",
+      topic,
+      project: "demo",
+      confidence: 0.9,
+      themes: [],
+    },
+    markdown: `## Summary\n\nbody for ${topic}`,
+  };
+}
+
+// Seed a DB row so the note is a real embedding-pool member.
+function record(id: string, topic: string): void {
+  db.record({
+    path: `/t/projects/demo/${id}.jsonl`,
+    hash: `h-${id}`,
+    skipped: false,
+    notePaths: [],
+    content: `body for ${topic}`,
+    category: "pattern",
+    topic,
+    project: "demo",
+    confidence: 0.9,
+    startedAt: "2026-05-01T10:00:00.000Z",
+  });
+}
+
+describe("Related links are regenerated, not hand-maintained", () => {
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "vir-related-"));
+    vault = join(root, "vault");
+    db = new StateDb(join(root, "vir.db"));
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("a rewrite drops a link to a note that has left the embedding pool", async () => {
+    const w = new VaultWriter(cfg(), db, stubProvider());
+    record("aaaa1111", "first topic");
+    record("bbbb2222", "second topic");
+    await w.write(session("aaaa1111"), note("first topic"));
+    const [keeper] = await w.write(session("bbbb2222"), note("second topic"));
+
+    expect(readFileSync(keeper!, "utf8")).toContain("first-topic-aaaa1111");
+
+    // Pruning removes the neighbour from getEmbeddings — the same gate the
+    // prune command sets.
+    db.markPruned("/t/projects/demo/aaaa1111.jsonl", "sidechain-transcript");
+
+    const w2 = new VaultWriter(cfg(), db, stubProvider());
+    const [rewritten] = await w2.write(
+      session("bbbb2222"),
+      note("second topic"),
+      "rewrite",
+    );
+
+    expect(readFileSync(rewritten!, "utf8")).not.toContain("first-topic-aaaa1111");
+  });
+
+  // A rewrite with no embedding provider has no vector, so it computes ZERO
+  // neighbours — which is indistinguishable from "this note has no relatives".
+  // Emitting that wipes every Related section in the vault, silently, in one
+  // pass. The existing section is the better answer until a provider can
+  // produce a new one.
+  it("a rewrite with no embedding provider preserves the existing Related section", async () => {
+    const w = new VaultWriter(cfg(), db, stubProvider());
+    record("aaaa1111", "first topic");
+    record("bbbb2222", "second topic");
+    await w.write(session("aaaa1111"), note("first topic"));
+    const [keeper] = await w.write(session("bbbb2222"), note("second topic"));
+    const before = readFileSync(keeper!, "utf8");
+    expect(before).toContain("## Related");
+
+    // No provider override, and no Ollama in the test environment.
+    const offline = new VaultWriter(cfg(), db);
+    const [rewritten] = await offline.write(
+      session("bbbb2222"),
+      note("second topic"),
+      "rewrite",
+    );
+
+    expect(readFileSync(rewritten!, "utf8")).toContain("## Related");
+    expect(readFileSync(rewritten!, "utf8")).toContain("first-topic-aaaa1111");
+  });
+});

--- a/src/pipeline/writer.ts
+++ b/src/pipeline/writer.ts
@@ -167,7 +167,15 @@ export class VaultWriter {
       vec && provider
         ? this.neighborLinks(vec, session.sessionId, provider.modelName)
         : [];
-    const body = strippedBody + renderRelatedSection(related);
+    // With no vector there are ZERO neighbours to compute — which renders
+    // identically to "this note has no relatives". Emitting that would wipe the
+    // Related section of every note in the vault in a single `--rewrite-only`
+    // pass with Ollama down, silently. The existing section is the better
+    // answer until a provider can produce a new one.
+    const body =
+      vec && provider
+        ? strippedBody + renderRelatedSection(related)
+        : strippedBody + this.preservedRelatedSection(priorPath);
 
     const finalContent = frontmatter + wikilinkHeader + body + "\n";
     writeFileSync(fullPath, finalContent);
@@ -536,6 +544,33 @@ export class VaultWriter {
         .filter((line) => !line.includes(marker))
         .join("\n"),
     );
+  }
+
+  // The existing note's Related block, verbatim, for a rewrite that could not
+  // embed. Mirrors preservedThemesBlock: carry forward what this pass cannot
+  // regenerate rather than emitting an empty section that reads as a fact.
+  private preservedRelatedSection(fullPath: string): string {
+    if (!existsSync(fullPath)) return "";
+    let content: string;
+    try {
+      content = readFileSync(fullPath, "utf8");
+    } catch {
+      return "";
+    }
+    const lines = content.split("\n");
+    const start = lines.findIndex((l) => /^##\s+related\b/i.test(l));
+    if (start === -1) return "";
+    const out: string[] = [];
+    for (const line of lines.slice(start + 1)) {
+      if (/^#{1,6}\s+/.test(line)) break;
+      out.push(line);
+    }
+    const bulletsEnd = out.reduce(
+      (last, line, i) => (line.trim().length > 0 ? i : last),
+      -1,
+    );
+    if (bulletsEnd === -1) return "";
+    return `\n\n## Related\n\n${out.slice(0, bulletsEnd + 1).join("\n").trim()}`;
   }
 
   private preservedReviewFields(fullPath: string): string[] {


### PR DESCRIPTION
Started as "fix the 177 dangling wikilinks left by `vir prune`". The links turned out not to be the bug.

## The links fix themselves

Related sections are **generated**, not hand-written: `neighborLinks` (`writer.ts:631`) reads `db.getEmbeddings`, which the prune gate already filters. So a note that leaves the embedding pool disappears from every Related section on the next `vir run --rewrite-only`, by construction. There is nothing to hand-edit, and hand-editing kept notes was explicitly out of bounds anyway.

A test now pins that: prune a neighbour, rewrite, assert the link is gone.

## The bug that was actually there

Writing that test exposed the hazard on the same path. With no embedding provider, `computeNoteEmbedding` returns null, so the writer computes **zero neighbours** — which renders identically to a note that genuinely has none:

```ts
const related = vec && provider ? this.neighborLinks(...) : [];
const body = strippedBody + renderRelatedSection(related);   // "" when empty
```

One `vir run --rewrite-only` pass with Ollama down would have stripped the Related section from **every note in the vault**, silently. The self-heal sweep does not undo it — it stores embeddings, it does not rewrite notes — so the damage persists until another rewrite with a working provider.

And that path is precisely what someone reaches for immediately after `vir prune --apply`, to clear the dangling links.

`write()` now falls back to `preservedRelatedSection` — the existing block, verbatim — whenever there is no vector, mirroring the existing `preservedThemesBlock` treatment of data a rewrite cannot regenerate.

## This is not hypothetical right now

Ollama is **not currently reachable** on this machine, and the last four logged queries all fell back to TF-IDF. Running `--rewrite-only` today, before this change, would have wiped Related across the whole vault.

## The consequence, stated plainly

Clearing dangling links **requires a working embedding provider**. With one down the rewrite preserves them — a no-op instead of a wipe. That is the safe failure, but it is not the fix, so the operational order after `--apply` is: bring the embedder up, *then* rewrite.

## Tests

587 pass, 57 files, `tsc` clean. Two new, both written first:
- a rewrite drops a link to a note that has left the embedding pool
- a rewrite with no embedding provider preserves the existing Related section

The `EmbeddingProvider` stub uses the writer's existing test seam (the `providerOverride` constructor arg added in 0.17.1).