### PR TITLE
feat: vir lint --strays — note files with no live DB row

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ developer-tools, mcp, local-first, cross-platform, llm-wiki
   <a href="https://www.npmjs.com/package/@djolex999/vir-cli"><img src="https://img.shields.io/npm/v/@djolex999/vir-cli?color=7c6af7&label=npm" alt="npm version"></a>
   <a href="https://www.npmjs.com/package/@djolex999/vir-cli"><img src="https://img.shields.io/npm/dw/@djolex999/vir-cli?color=4fd1a0" alt="npm downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22d3ee" alt="license"></a>
-  <a href="#project-status"><img src="https://img.shields.io/badge/tests-587%20passing-22c55e" alt="tests"></a>
+  <a href="#project-status"><img src="https://img.shields.io/badge/tests-593%20passing-22c55e" alt="tests"></a>
   <a href="#project-status"><img src="https://img.shields.io/badge/platforms-macOS%20%7C%20Linux-lightgrey" alt="platforms"></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-server-c084fc" alt="mcp"></a>
   <a href="#"><img src="https://img.shields.io/badge/local--first-yes-f59e0b" alt="local-first"></a>
@@ -362,6 +362,7 @@ with your distro, init system, and Node version.
 | `vir lint`                  | cheap | Find orphans, stale notes, contradictions |
 | `vir dedupe`                | cheap | Interactive duplicate detection + merge   |
 | `vir review`                | free  | Walk new notes: approve/edit/reject       |
+| `vir lint --strays`         | free  | Note files with no live DB row (retitle debris) |
 | `vir prune`                 | free  | Dry run: agent-derived notes to demote    |
 | `vir prune --apply`         | free  | Demote them to `.rejected/` (never deletes) |
 | `vir prune --restore`       | free  | Put every pruned note back, exactly       |
@@ -508,7 +509,7 @@ improvements. Delete it any time; disable it with `"logQueries": false` in
 |                |                                           |
 | -------------- | ----------------------------------------- |
 | Version        | 0.17.6                                    |
-| Tests          | 587 passing                               |
+| Tests          | 593 passing                               |
 | Platforms      | macOS (launchd), Linux (systemd/cron)     |
 | Node           | 20+                                       |
 | First-run cost | $1 to $5 (Kie.ai optional, ~72% cheaper)  |

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -23,14 +23,14 @@ export const INSTALL_CMD = `npm install -g ${NPM_PKG}`;
 //   transcriptsSeen  — rows in the sessions table
 //   transcriptsNoise — skip_reason in (workflow-transcript, agent-transcript, sidechain-transcript)
 //   transcriptsNotes — skipped=0 and note_paths != '[]'
-//   tests            — `npm test` at the repo root (587 CLI; the site's 18 are separate)
+//   tests            — `npm test` at the repo root (593 CLI; the site's 18 are separate)
 //   cost*            — `vir cost --since 180d`
 export const NUMBERS = {
   sessionsRescued: 396,
   transcriptsSeen: 1429,
   transcriptsNoise: 601,
   transcriptsNotes: 411,
-  tests: 587 as number | null,
+  tests: 593 as number | null,
   costWindow: "six months",
   costSessions: 296,
   costTotal: "$22.23" as string | null,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,7 @@ import {
   orphanCheck,
   stalenessCheck,
 } from "./lint/linter.js";
+import { strayFileCheck } from "./lint/strayFiles.js";
 import { runPipeline } from "./pipeline/run.js";
 import {
   categorizeTranscriptHead,
@@ -724,22 +725,28 @@ program
 
 program
   .command("lint")
-  .description("Run orphan, staleness, and contradiction checks on the vault")
+  .description(
+    "Run orphan, stray-file, staleness, and contradiction checks on the vault",
+  )
   .option("--orphans", "Run only the orphan check (free)")
+  .option("--strays", "Run only the stray-file check (free)")
   .option("--stale", "Run only the staleness check (free)")
   .option("--contradictions", "Run only the contradiction check (Haiku tokens)")
   .action(
     runAction(async (opts: {
       orphans?: boolean;
+      strays?: boolean;
       stale?: boolean;
       contradictions?: boolean;
     }) => {
       const cfg = loadConfig();
       const db = new StateDb();
       try {
-        const runAll = !opts.orphans && !opts.stale && !opts.contradictions;
+        const runAll =
+          !opts.orphans && !opts.strays && !opts.stale && !opts.contradictions;
         const checks: string[] = [];
         if (runAll || opts.orphans) checks.push("orphans");
+        if (runAll || opts.strays) checks.push("strays");
         if (runAll || opts.stale) checks.push("stale");
         if (runAll || opts.contradictions) checks.push("contradictions");
 
@@ -747,6 +754,7 @@ program
         ui.blank();
 
         let orphanCount = 0;
+        let strayCount = 0;
         let staleCount = 0;
         let contradictionCount = 0;
         let issues = 0;
@@ -763,6 +771,33 @@ program
             ui.row(ui.errorColor(ui.CROSS), `${ui.text("orphans")} ${ui.dim("(" + orphanCount + ")")}`);
             for (const o of r.orphans) {
               console.log(`   ${ui.dim(ui.BULLET)} ${ui.text(ui.shortNotePath(o))}`);
+            }
+          }
+        }
+
+        if (runAll || opts.strays) {
+          const sp = ui.spinner("checking stray files").start();
+          const r = strayFileCheck(cfg, db);
+          sp.stop();
+          strayCount = r.strays.length;
+          issues += strayCount;
+          if (strayCount === 0) {
+            ui.row(ui.success(ui.CHECK), `${ui.text("strays")}   ${ui.dim("none")}`);
+          } else {
+            ui.row(
+              ui.errorColor(ui.CROSS),
+              `${ui.text("strays")} ${ui.dim("(" + strayCount + " of " + r.scanned + " files)")}`,
+            );
+            for (const st of r.strays) {
+              // The sibling is the whole point: it is what makes a stray safe
+              // to demote. An `unknown` stray has none, and gets no advice.
+              const note =
+                st.liveSibling !== null
+                  ? ui.dim(`${ui.ARROW} live: ${st.liveSibling}`)
+                  : ui.warn("only copy — inspect before removing");
+              console.log(
+                `   ${ui.dim(ui.BULLET)} ${ui.text(ui.shortNotePath(st.relPath))}  ${ui.muted(st.kind)}  ${note}`,
+              );
             }
           }
         }
@@ -818,6 +853,7 @@ program
             color: issues > 0 ? ui.errorColor : ui.success,
           },
           orphans: { value: orphanCount, color: ui.muted },
+          strays: { value: strayCount, color: ui.muted },
           stale: { value: staleCount, color: ui.muted },
           contradictions: { value: contradictionCount, color: ui.muted },
         });

--- a/src/lint/strayFiles.test.ts
+++ b/src/lint/strayFiles.test.ts
@@ -1,0 +1,123 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Config } from "../config.js";
+import { StateDb } from "../state/db.js";
+import { strayFileCheck } from "./strayFiles.js";
+
+let root: string;
+let vault: string;
+let db: StateDb;
+
+function cfg(): Config {
+  return { vaultPath: vault, outputDir: "vir" } as Config;
+}
+
+// A distilled row plus the note file the writer would have produced for it.
+function seed(opts: {
+  sessionId: string;
+  topic: string;
+  content?: string | null;
+  pruned?: boolean;
+}): void {
+  const path = `/t/projects/demo/${opts.sessionId}.jsonl`;
+  db.record({
+    path,
+    hash: `h-${opts.sessionId}`,
+    skipped: false,
+    notePaths: [],
+    content: opts.content === undefined ? "body" : opts.content,
+    category: "pattern",
+    topic: opts.topic,
+    project: "demo",
+    confidence: 0.9,
+    startedAt: "2026-05-01T00:00:00.000Z",
+  });
+  if (opts.pruned === true) db.markPruned(path, "sidechain-transcript");
+}
+
+function writeNote(slug: string): void {
+  const dir = join(vault, "vir", "patterns");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(dir + `/${slug}.md`, `---\ntopic: "x"\n---\n\nbody\n`);
+}
+
+describe("strayFileCheck", () => {
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "vir-stray-"));
+    vault = join(root, "vault");
+    db = new StateDb(join(root, "vir.db"));
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("finds nothing when every file is backed by a live row", () => {
+    seed({ sessionId: "aaaa1111", topic: "first topic" });
+    writeNote("first-topic-aaaa1111");
+
+    expect(strayFileCheck(cfg(), db).strays).toEqual([]);
+  });
+
+  // The file the writer left behind when the distiller retitled a session
+  // before 0.17.3 removed the old path. Its session has a live note under the
+  // new title, so the content is not unique.
+  it("flags a retitle duplicate and names its live sibling", () => {
+    seed({ sessionId: "aaaa1111", topic: "new title" });
+    writeNote("new-title-aaaa1111");
+    writeNote("old-title-aaaa1111");
+
+    const r = strayFileCheck(cfg(), db);
+
+    expect(r.strays).toHaveLength(1);
+    expect(r.strays[0]?.relPath).toContain("old-title-aaaa1111.md");
+    expect(r.strays[0]?.kind).toBe("retitle-duplicate");
+    expect(r.strays[0]?.liveSibling).toBe("new-title-aaaa1111");
+  });
+
+  // The trap that nearly demoted a real note during the live cleanup: a
+  // session awaiting `vir reconcile` has an EMPTY content column, but it is a
+  // live note and its file on disk is the only copy of that text. Content must
+  // not be part of the test.
+  it("never flags a note whose row is awaiting reconcile", () => {
+    seed({ sessionId: "bbbb2222", topic: "pending topic", content: "" });
+    writeNote("pending-topic-bbbb2222");
+
+    expect(strayFileCheck(cfg(), db).strays).toEqual([]);
+  });
+
+  it("flags a file with no row at all as unknown, not as a duplicate", () => {
+    writeNote("who-knows-cccc3333");
+
+    const r = strayFileCheck(cfg(), db);
+
+    expect(r.strays).toHaveLength(1);
+    expect(r.strays[0]?.kind).toBe("unknown");
+    expect(r.strays[0]?.liveSibling).toBeNull();
+  });
+
+  // A pruned note lives in `.rejected/`, so a file left in a category dir for
+  // a pruned session is debris — but it is NOT a retitle duplicate, and saying
+  // so would invite deleting the only copy.
+  it("classifies a file whose session was pruned as pruned-leftover", () => {
+    seed({ sessionId: "dddd4444", topic: "pruned topic", pruned: true });
+    writeNote("pruned-topic-dddd4444");
+
+    const r = strayFileCheck(cfg(), db);
+
+    expect(r.strays).toHaveLength(1);
+    expect(r.strays[0]?.kind).toBe("pruned-leftover");
+  });
+
+  it("ignores .rejected/ and archived/ entirely", () => {
+    for (const sub of [".rejected", "archived"]) {
+      const dir = join(vault, "vir", sub);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "whatever-eeee5555.md"), "---\n---\nbody\n");
+    }
+
+    expect(strayFileCheck(cfg(), db).strays).toEqual([]);
+  });
+});

--- a/src/lint/strayFiles.ts
+++ b/src/lint/strayFiles.ts
@@ -1,0 +1,88 @@
+import { existsSync, readdirSync } from "node:fs";
+import { basename, join, relative } from "node:path";
+import type { Config } from "../config.js";
+import { makeSlug, sessionSuffix } from "../pipeline/slug.js";
+import { CATEGORY_DIR } from "../pipeline/writer.js";
+import type { StateDb } from "../state/db.js";
+
+// Why a note file has no live row behind it.
+//   retitle-duplicate — the distiller renamed the session and the writer left
+//     the old path behind (every release before 0.17.3). Its session still has
+//     a live note under the new title, so nothing unique is in this file.
+//   pruned-leftover  — the session was pruned; the demoted copy belongs in
+//     `.rejected/`, so a file still sitting in a category dir is debris.
+//   unknown          — no row produces this filename at all. Reported without
+//     a recommendation: it may be the only copy of its content.
+export type StrayKind = "retitle-duplicate" | "pruned-leftover" | "unknown";
+
+export interface StrayFile {
+  relPath: string;
+  kind: StrayKind;
+  // The live note for the same session, when there is one. Its existence is
+  // what makes a stray safe to demote.
+  liveSibling: string | null;
+}
+
+export interface StrayResult {
+  scanned: number;
+  strays: StrayFile[];
+}
+
+function deriveSessionId(path: string): string {
+  return basename(path).replace(/\.jsonl$/, "");
+}
+
+// Note files in a category dir that no live DB row can account for.
+//
+// The test is "can any non-pruned row produce this filename", NOT "does a row
+// with content produce it". A session awaiting `vir reconcile` has an empty
+// content column while its note file on disk holds the only copy of the text —
+// judging on content would flag that as debris and demote a real note.
+export function strayFileCheck(cfg: Config, db: StateDb): StrayResult {
+  const root = join(cfg.vaultPath, cfg.outputDir);
+
+  const live = new Map<string, string>(); // slug -> slug (live notes)
+  const liveBySession = new Map<string, string>(); // session suffix -> slug
+  const prunedSlugs = new Set<string>();
+
+  for (const row of db.listAllNoteRows()) {
+    const sessionId = deriveSessionId(row.path);
+    const slug = makeSlug(row.topic, sessionId);
+    if (row.pruned_at !== null) {
+      prunedSlugs.add(slug);
+      continue;
+    }
+    live.set(slug, slug);
+    liveBySession.set(sessionSuffix(sessionId), slug);
+  }
+
+  const strays: StrayFile[] = [];
+  let scanned = 0;
+
+  // `.rejected/` and `archived/` are where demoted notes are SUPPOSED to live —
+  // they are never walked.
+  for (const sub of Object.values(CATEGORY_DIR)) {
+    const dir = join(root, sub);
+    if (!existsSync(dir)) continue;
+    for (const name of readdirSync(dir)) {
+      if (!name.endsWith(".md")) continue;
+      scanned += 1;
+      const slug = name.slice(0, -".md".length);
+      if (live.has(slug)) continue;
+
+      const sibling = liveBySession.get(slug.split("-").pop() ?? "") ?? null;
+      const kind: StrayKind = prunedSlugs.has(slug)
+        ? "pruned-leftover"
+        : sibling !== null
+          ? "retitle-duplicate"
+          : "unknown";
+      strays.push({
+        relPath: relative(root, join(dir, name)),
+        kind,
+        liveSibling: sibling,
+      });
+    }
+  }
+
+  return { scanned, strays };
+}

--- a/src/pipeline/writer.related.test.ts
+++ b/src/pipeline/writer.related.test.ts
@@ -143,8 +143,15 @@ describe("Related links are regenerated, not hand-maintained", () => {
     const before = readFileSync(keeper!, "utf8");
     expect(before).toContain("## Related");
 
-    // No provider override, and no Ollama in the test environment.
-    const offline = new VaultWriter(cfg(), db);
+    // `embeddingProvider: "none"` makes resolveEmbeddingProvider return null
+    // by configuration. The first version of this test just omitted the
+    // override and relied on Ollama being absent from the machine — so it
+    // passed until someone started Ollama, which is precisely the
+    // machine-dependent assertion the providerOverride seam exists to avoid.
+    const offline = new VaultWriter(
+      { ...cfg(), embeddingProvider: "none" } as Config,
+      db,
+    );
     const [rewritten] = await offline.write(
       session("bbbb2222"),
       note("second topic"),

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -470,6 +470,34 @@ export class StateDb {
   // Every distilled row with the fields the prune classifier needs. Already
   // pruned rows are included so a plan can report them instead of counting
   // them again as fresh candidates.
+  // Every row that could have produced a note file, pruned or not, WITHOUT
+  // filtering on content. A session awaiting reconcile has an empty content
+  // column but its note file on disk is real — a caller deciding whether a file
+  // is debris must see that row, or it will call a live note an orphan.
+  listAllNoteRows(): Array<{
+    path: string;
+    topic: string;
+    category: Category;
+    pruned_at: string | null;
+  }> {
+    const prunedCol = this.columnsOf("sessions").has("pruned_at");
+    return this.db
+      .prepare(
+        `SELECT path, topic, category${prunedCol ? ", pruned_at" : ", NULL AS pruned_at"}
+         FROM sessions
+         WHERE skipped = 0
+           AND topic IS NOT NULL
+           AND category IS NOT NULL
+           AND COALESCE(archived, 0) = 0`,
+      )
+      .all() as Array<{
+      path: string;
+      topic: string;
+      category: Category;
+      pruned_at: string | null;
+    }>;
+  }
+
   listPruneCandidates(): PruneCandidateRow[] {
     if (!this.columnsOf("sessions").has("pruned_at")) return [];
     return this.db


### PR DESCRIPTION
Folds the orphan detection from the live vault cleanup into `vir lint` as a tested command, replacing the one-off script.

## What it finds

Pre-0.17.3 retitle debris: the distiller renames a session, the writer writes the new slug, and the old file stays behind. **32 files in the reference vault** — one session accounts for five of them:

```
✗ strays (32 of 301 files)
   · patterns/append-only-audit-log-over-mutations-3b8fde15  retitle-duplicate  → live: append-only-audit-log-eliminates-conflicts-3b8fde15
   · patterns/append-only-log-audit-trail-3b8fde15           retitle-duplicate  → live: append-only-audit-log-eliminates-conflicts-3b8fde15
   · gotchas/null-semantics-break-silently-f4c7d393          retitle-duplicate  → live: ollama-probe-null-breaks-inference-f4c7d393
   …
```

Naming the live sibling is the point: it is what makes a stray safe to demote.

## They are not harmless — I had this wrong

I previously described these as invisible to retrieval. That is true only of the embedding path, which builds `filePath` from the note's CURRENT topic and so never resolves a stale slug. **The TF-IDF walk indexes every category dir** (`retriever.ts:18` skips only `summaries`, `.rejected`, `archived`), so a stray is fully retrievable whenever the embedder is down.

It is in this vault's own query log: a `vir_query` this morning returned `three-state-project-triage-before-cost-990e18b0` *and* `filter-before-classify-paid-boundary-990e18b0` as two separate sources — one session, cited twice under two titles, crowding out other notes in the top-k.

## The trap the test pins

The check asks whether **any non-pruned row can produce this filename**. It deliberately ignores the content column.

A session awaiting `vir reconcile` has an empty `content` while its file on disk holds the only copy of the text. The one-off script I wrote during the live cleanup keyed on "no serving row", where serving required non-empty content — so it flagged `centralize-serialization-to-prevent-divergence-c16d4b65` as debris. That is a live note with 29 siblings in the same state. Caught it in the dry run, before anything moved. There is now a test for exactly that case.

## Classification, not just a count

- `retitle-duplicate` — a live sibling shares the session id, so nothing unique is in the file
- `pruned-leftover` — the session was pruned; the demoted copy belongs in `.rejected/`
- `unknown` — no row produces it at all. Reported with **no** recommendation, and flagged `only copy — inspect before removing`

Reporting only: nothing is moved or deleted. `--strays` runs it alone; it is also part of a bare `vir lint`.

## A flaky test of my own, fixed

`writer.related.test.ts` asserted "no embedding provider" by relying on Ollama being absent from the machine. Starting Ollama on this box broke it immediately — the exact machine-dependent assertion the `providerOverride` seam was added to prevent. It now sets `embeddingProvider: "none"` explicitly.

## Tests

593 pass, 58 files, `tsc` clean. 6 new, each RED first.