### PR TITLE
feat: surface distill failures where they can still be acted on

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ developer-tools, mcp, local-first, cross-platform, llm-wiki
   <a href="https://www.npmjs.com/package/@djolex999/vir-cli"><img src="https://img.shields.io/npm/v/@djolex999/vir-cli?color=7c6af7&label=npm" alt="npm version"></a>
   <a href="https://www.npmjs.com/package/@djolex999/vir-cli"><img src="https://img.shields.io/npm/dw/@djolex999/vir-cli?color=4fd1a0" alt="npm downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22d3ee" alt="license"></a>
-  <a href="#project-status"><img src="https://img.shields.io/badge/tests-593%20passing-22c55e" alt="tests"></a>
+  <a href="#project-status"><img src="https://img.shields.io/badge/tests-602%20passing-22c55e" alt="tests"></a>
   <a href="#project-status"><img src="https://img.shields.io/badge/platforms-macOS%20%7C%20Linux-lightgrey" alt="platforms"></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-server-c084fc" alt="mcp"></a>
   <a href="#"><img src="https://img.shields.io/badge/local--first-yes-f59e0b" alt="local-first"></a>
@@ -509,7 +509,7 @@ improvements. Delete it any time; disable it with `"logQueries": false` in
 |                |                                           |
 | -------------- | ----------------------------------------- |
 | Version        | 0.17.7                                    |
-| Tests          | 593 passing                               |
+| Tests          | 602 passing                               |
 | Platforms      | macOS (launchd), Linux (systemd/cron)     |
 | Node           | 20+                                       |
 | First-run cost | $1 to $5 (Kie.ai optional, ~72% cheaper)  |

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -23,14 +23,14 @@ export const INSTALL_CMD = `npm install -g ${NPM_PKG}`;
 //   transcriptsSeen  — rows in the sessions table
 //   transcriptsNoise — skip_reason in (workflow-transcript, agent-transcript, sidechain-transcript)
 //   transcriptsNotes — skipped=0 and note_paths != '[]'
-//   tests            — `npm test` at the repo root (593 CLI; the site's 18 are separate)
+//   tests            — `npm test` at the repo root (602 CLI; the site's 18 are separate)
 //   cost*            — `vir cost --since 180d`
 export const NUMBERS = {
   sessionsRescued: 396,
   transcriptsSeen: 1429,
   transcriptsNoise: 601,
   transcriptsNotes: 411,
-  tests: 593 as number | null,
+  tests: 602 as number | null,
   costWindow: "six months",
   costSessions: 296,
   costTotal: "$22.23" as string | null,

--- a/src/diagnostics/distillFailures.test.ts
+++ b/src/diagnostics/distillFailures.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  distillFailureCheck,
+  failureNotice,
+  type DistillFailureState,
+} from "./distillFailures.js";
+
+const NOW = Date.parse("2026-09-11T12:00:00.000Z");
+const DAY = 86_400_000;
+const state = (over: Partial<DistillFailureState> = {}): DistillFailureState => ({
+  total: 0,
+  recoverable: 0,
+  lastFailureAt: null,
+  worstDay: null,
+  ...over,
+});
+
+// This check exists because 15 sessions died in one `fetch failed` window on
+// 2026-06-11 and nobody noticed for three months. By the time anyone looked,
+// Claude Code had deleted the transcripts and the knowledge was gone for good.
+// The daemon runs unattended: if a bad afternoon is not surfaced somewhere the
+// user actually looks, it becomes permanent loss.
+describe("distillFailureCheck", () => {
+  it("says nothing when there have been no failures", () => {
+    expect(distillFailureCheck(state(), NOW)).toBeNull();
+  });
+
+  it("FAILS on recent failures — this is the window where recovery is possible", () => {
+    const r = distillFailureCheck(
+      state({
+        total: 15,
+        recoverable: 15,
+        lastFailureAt: new Date(NOW - 2 * DAY).toISOString(),
+        worstDay: { date: "2026-09-09", count: 15 },
+      }),
+      NOW,
+    );
+
+    expect(r?.status).toBe("fail");
+    expect(r?.detail).toContain("15");
+    expect(r?.detail).toContain("vir reconcile");
+  });
+
+  it("names the cluster, because one bad window is the signal", () => {
+    const r = distillFailureCheck(
+      state({
+        total: 18,
+        recoverable: 3,
+        lastFailureAt: new Date(NOW - 1 * DAY).toISOString(),
+        worstDay: { date: "2026-09-10", count: 15 },
+      }),
+      NOW,
+    );
+
+    expect(r?.detail).toContain("2026-09-10");
+    expect(r?.detail).toContain("15");
+  });
+
+  // Old but still retryable: the transcripts have not expired yet, so this is
+  // a warning with an action, not an alarm.
+  it("WARNS when failures are old but still recoverable", () => {
+    const r = distillFailureCheck(
+      state({
+        total: 9,
+        recoverable: 9,
+        lastFailureAt: new Date(NOW - 30 * DAY).toISOString(),
+        worstDay: { date: "2026-08-12", count: 9 },
+      }),
+      NOW,
+    );
+
+    expect(r?.status).toBe("warn");
+    expect(r?.detail).toContain("vir reconcile");
+  });
+
+  // Nothing to do: the transcripts are gone, so reconcile cannot help. Say so
+  // plainly instead of showing a red row that implies pending work forever.
+  it("reports unrecoverable failures as ok, with no call to action", () => {
+    const r = distillFailureCheck(
+      state({
+        total: 28,
+        recoverable: 0,
+        lastFailureAt: "2026-07-07T10:00:00.000Z",
+        worstDay: { date: "2026-06-11", count: 15 },
+      }),
+      NOW,
+    );
+
+    expect(r?.status).toBe("ok");
+    expect(r?.detail).toContain("28");
+    expect(r?.detail).toContain("unrecoverable");
+    expect(r?.detail).not.toContain("vir reconcile");
+  });
+
+  it("counts recoverable separately from the total", () => {
+    const r = distillFailureCheck(
+      state({
+        total: 29,
+        recoverable: 1,
+        lastFailureAt: new Date(NOW - 40 * DAY).toISOString(),
+        worstDay: { date: "2026-06-11", count: 15 },
+      }),
+      NOW,
+    );
+
+    expect(r?.detail).toContain("1");
+    expect(r?.detail).toContain("29");
+  });
+});
+
+// Doctor only helps someone who runs doctor. The daemon runs unattended, so a
+// bad window needs to reach the user the day it happens — that is the whole
+// difference between "reconcile recovers it" and "the transcript expired".
+describe("failureNotice", () => {
+  it("says nothing when a run had no errors", () => {
+    expect(failureNotice(0)).toBeNull();
+  });
+
+  it("names the count and the recovery command", () => {
+    const n = failureNotice(15);
+    expect(n?.title).toContain("vir");
+    expect(n?.message).toContain("15");
+    expect(n?.message).toContain("vir reconcile");
+  });
+
+  it("is singular for one failure", () => {
+    expect(failureNotice(1)?.message).toContain("1 session");
+    expect(failureNotice(1)?.message).not.toContain("1 sessions");
+  });
+})

--- a/src/diagnostics/distillFailures.ts
+++ b/src/diagnostics/distillFailures.ts
@@ -1,0 +1,93 @@
+import type { CheckStatus } from "../ui/display.js";
+
+// A failure is "recent" while Claude Code still holds the transcript (it prunes
+// at ~30 days). Inside this window a failed session can still be recovered, so
+// it is worth interrupting for; outside it, the answer may already be "too
+// late" and the row is informational.
+const RECENT_FAILURE_DAYS = 7;
+
+export interface DistillFailureState {
+  // Sessions carrying a distill error that never produced a note.
+  total: number;
+  // Of those, the ones whose transcript is still on disk — the only ones
+  // `vir reconcile` can do anything with.
+  recoverable: number;
+  lastFailureAt: string | null;
+  // The single worst day. A cluster is the signal: 15 sessions failing in one
+  // afternoon is an outage, whereas 15 spread over a quarter is ordinary noise.
+  worstDay: { date: string; count: number } | null;
+}
+
+export interface DistillFailureResult {
+  status: CheckStatus;
+  label: string;
+  detail: string;
+}
+
+function daysSince(iso: string | null, now: number): number | null {
+  if (iso === null) return null;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? null : (now - t) / 86_400_000;
+}
+
+// Surface distill failures where the user actually looks.
+//
+// The daemon runs unattended every few hours. When a provider outage kills a
+// batch, run.ts records an error row per session and moves on — correct
+// behaviour, but the only trace is daemon.log, which nobody reads. In this
+// vault 15 sessions died in one window and were found three months later, by
+// which time the transcripts had expired and the knowledge was unrecoverable.
+export function distillFailureCheck(
+  s: DistillFailureState,
+  now: number,
+): DistillFailureResult | null {
+  if (s.total === 0) return null;
+
+  const label = "distill failures";
+  const age = daysSince(s.lastFailureAt, now);
+  const cluster =
+    s.worstDay !== null && s.worstDay.count > 1
+      ? ` · worst day ${s.worstDay.date} (${s.worstDay.count})`
+      : "";
+  const lastSeen =
+    s.lastFailureAt !== null ? ` · last ${s.lastFailureAt.slice(0, 10)}` : "";
+
+  // Nothing retryable: the transcripts are gone, so reconcile cannot help.
+  // Report it plainly rather than showing a red row that implies pending work
+  // forever — an alarm nobody can act on is an alarm nobody reads.
+  if (s.recoverable === 0) {
+    return {
+      status: "ok",
+      label,
+      detail: `${s.total} unrecoverable (transcripts expired)${lastSeen}${cluster}`,
+    };
+  }
+
+  const recent = age !== null && age <= RECENT_FAILURE_DAYS;
+  return {
+    status: recent ? "fail" : "warn",
+    label,
+    detail:
+      `${s.recoverable} of ${s.total} still recoverable${lastSeen}${cluster}` +
+      ` — run \`vir reconcile\` before the transcripts expire`,
+  };
+}
+
+export interface FailureNotice {
+  title: string;
+  message: string;
+}
+
+// The same-day half of failure visibility. run.ts already notifies for
+// projects awaiting a decision; a run that dropped sessions on the floor is at
+// least as worth knowing about, and unlike the doctor row it reaches the user
+// without them going looking. Pure so the thresholds are testable — the
+// osascript call itself is not.
+export function failureNotice(errored: number): FailureNotice | null {
+  if (errored <= 0) return null;
+  const noun = errored === 1 ? "session" : "sessions";
+  return {
+    title: "vir — distill failures",
+    message: `${errored} ${noun} failed to distill — run \`vir reconcile\` while the transcripts still exist`,
+  };
+}

--- a/src/diagnostics/doctor.ts
+++ b/src/diagnostics/doctor.ts
@@ -40,6 +40,7 @@ import { CLAUDE_CLI_LIMIT_MARKER_PATH } from "../pipeline/claudeCli.js";
 import { isClaudeAvailable, isInstalled } from "../mcp/install.js";
 import { gatherProjectsReport } from "../cli/projects.js";
 import { StateDb } from "../state/db.js";
+import { distillFailureCheck } from "./distillFailures.js";
 import { buildDoctorResult } from "../output/json.js";
 import * as ui from "../ui/display.js";
 
@@ -529,6 +530,45 @@ function checkBackup(): CheckResult | null {
 // undo it. Null when nothing is pruned — doctor should not grow a row for a
 // feature the user has not used. Human table ONLY, never doctor --json (the
 // 8-field VirDoctorResult is a cross-repo contract).
+// Reads the failure rows and resolves recoverability against the filesystem:
+// `vir reconcile` can only retry a session whose transcript still exists.
+function checkDistillFailures(): CheckResult | null {
+  let db: StateDb | null = null;
+  try {
+    db = new StateDb(STATE_PATH, { readonly: true });
+    const rows = db.listDistillFailures();
+    if (rows.length === 0) return null;
+    let recoverable = 0;
+    let lastFailureAt: string | null = null;
+    const byDay = new Map<string, number>();
+    for (const r of rows) {
+      if (existsSync(r.path)) recoverable += 1;
+      const day = (r.processed_at ?? "").slice(0, 10);
+      if (day.length === 10) byDay.set(day, (byDay.get(day) ?? 0) + 1);
+      if (lastFailureAt === null || r.processed_at > lastFailureAt) {
+        lastFailureAt = r.processed_at;
+      }
+    }
+    let worstDay: { date: string; count: number } | null = null;
+    for (const [date, count] of byDay) {
+      if (worstDay === null || count > worstDay.count) worstDay = { date, count };
+    }
+    const r = distillFailureCheck(
+      { total: rows.length, recoverable, lastFailureAt, worstDay },
+      Date.now(),
+    );
+    return r === null ? null : { status: r.status, label: r.label, detail: r.detail };
+  } catch {
+    return null;
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // ignore
+    }
+  }
+}
+
 function checkPrunedNotes(): CheckResult | null {
   let db: StateDb | null = null;
   try {
@@ -786,6 +826,8 @@ export async function runDoctor(): Promise<void> {
   const backup = checkBackup();
   if (backup) record(backup);
   record(checkQueryLog(cfg));
+  const failures = checkDistillFailures();
+  if (failures) record(failures);
   const pruned = checkPrunedNotes();
   if (pruned) record(pruned);
   const limitPattern = checkClaudeCliLimitPattern(cfg);

--- a/src/pipeline/run.ts
+++ b/src/pipeline/run.ts
@@ -12,6 +12,7 @@ import {
 } from "./distiller.js";
 import { computeCost } from "../cost/pricing.js";
 import { scoreSession } from "./filter.js";
+import { failureNotice } from "../diagnostics/distillFailures.js";
 import { parseSession } from "./parser.js";
 import { scanSessions } from "./scanner.js";
 import { scanArticles } from "./articleReader.js";
@@ -1080,6 +1081,20 @@ export async function runPipeline(
         "vir — projects awaiting decision",
         `${stillPending.size} project(s), ${summary.projectPending} session(s) pending — run vir projects`,
       );
+    }
+  }
+
+  // A run that dropped sessions on the floor is worth knowing about the day it
+  // happens. run.ts already records an error row per failure and logs it, but
+  // the daemon runs unattended and nobody reads daemon.log — which is how 15
+  // sessions died in one window here and were found three months later, after
+  // Claude Code had deleted the transcripts. Doctor carries the standing state;
+  // this is the part that reaches the user in time to act.
+  const notice = failureNotice(summary.errored);
+  if (notice !== null) {
+    fileLog(`${summary.errored} session(s) failed to distill this run`);
+    if (cfg.notifications !== false && process.platform === "darwin") {
+      notify(notice.title, notice.message);
     }
   }
 

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -474,6 +474,23 @@ export class StateDb {
   // filtering on content. A session awaiting reconcile has an empty content
   // column but its note file on disk is real — a caller deciding whether a file
   // is debris must see that row, or it will call a live note an orphan.
+  // Sessions that errored and never produced a note. Used by the doctor
+  // failure check, which decides recoverability by looking at whether each
+  // transcript still exists on disk — a filesystem question, so the rows come
+  // back raw rather than being counted here.
+  listDistillFailures(): Array<{ path: string; processed_at: string }> {
+    const gate = this.prunedGate();
+    return this.db
+      .prepare(
+        `SELECT path, processed_at
+         FROM sessions
+         WHERE skipped = 0
+           AND error IS NOT NULL AND error != ''
+           AND (content IS NULL OR content = '')${gate}`,
+      )
+      .all() as Array<{ path: string; processed_at: string }>;
+  }
+
   listAllNoteRows(): Array<{
     path: string;
     topic: string;


### PR DESCRIPTION
Closes the gap the reconcile audit exposed: **14 sessions died in one `fetch failed` window on 2026-06-11 and nobody noticed for three months.** By the time anyone looked, Claude Code had deleted the transcripts and the knowledge was gone. This vault holds 27 such rows and **not one of them is recoverable**.

`run.ts` did everything right — recorded an error row per failure, logged it, moved on. That is also exactly why it was invisible: the daemon runs unattended and nobody reads `daemon.log`.

## Two sides, because either alone leaves the hole

**`failureNotice`** fires a desktop notification at the end of any run that errored, mirroring the existing projects-awaiting-decision notice. This is the half that reaches you *the same day*, while `vir reconcile` can still do something.

**A `distill failures` doctor row** carries the standing state — how many failed, how many are still recoverable, when the last one was, and the worst single day. The cluster is the signal: 15 failures in one afternoon is an outage, 15 across a quarter is noise.

## Severity keys on recoverability, not count

Recoverable means the transcript still exists on disk — the only thing `vir reconcile` can act on.

| State | Status | Why |
|---|---|---|
| Recent (≤7d) and recoverable | `fail` | The window where recovery is still possible |
| Older but recoverable | `warn` | Actionable, not urgent |
| Transcripts expired | `ok` | Nothing to do — say so plainly |

That last row matters. A permanent red row for work nobody can do teaches people to ignore the whole table, so once the transcripts are gone the check reports the fact without a call to action.

Live output here:

```
✓ distill failures     27 unrecoverable (transcripts expired) · last 2026-07-07 · worst day 2026-06-11 (14)
```

## A correction

I have been saying "15 sessions" in this thread. Reading it against the real data, the worst day is **14** — the 15th row on that date did produce a note and so is not a distill failure. The check counts only rows that errored *and* produced nothing.

## Tests

602 pass, 59 files, `tsc` clean. 9 new, each RED first. The check and the notice are pure functions taking state, following `queryLogCheck`/`backupCheck`; the `osascript` call stays untested, and the thresholds around it do not.

Human table only — the 8-field `doctor --json` contract is verified unchanged.